### PR TITLE
Add mappings for WinMain related functions

### DIFF
--- a/scripts/headers/bw1_decomp_gen/vanilla_filepaths.py
+++ b/scripts/headers/bw1_decomp_gen/vanilla_filepaths.py
@@ -1662,6 +1662,12 @@ ROOMMATE_CLASS_MAP = {
     "AddSpecialRPObjects__FP8RPHolder": "RPHolder",
     "CheckSquareFunction__FiiP8RPHolder": "RPHolder",
     "GFlockInfo": "Flock",
+    "DoCitadelMultiplayer__Fv": "Game",
+    "MakeTipVideo__Fv": "LoadingScreen",
+    "PlayPreIntroVideo__Fv": "PCMain",
+    "PlayLogoScreens__Fv": "PCMain",
+    "start_system__Fv": "PCMain",
+    "FreeFonts__Fv": "PCMain",
 }
 
 


### PR DESCRIPTION
There are a few global functions in #111 that require some new vanilla file paths for roommate functions. Luckily most of the missing functions had `__nw__` calls with `__FILE__` as a parameter.