### PR TITLE
llvm: Use patched llvm that doesn't put noreturn in pdb

### DIFF
--- a/.github/actions/clang_prep/action.yml
+++ b/.github/actions/clang_prep/action.yml
@@ -3,7 +3,7 @@ description: 'Setup the correct version of clang to compile this recomp.'
 inputs:
   llvm_tag:
     description: 'LLVM tag to download'
-    default: 'bw1-decomp-011'
+    default: 'bw1-decomp-012'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Ghidra is having issues with functions that are put into c files and made to generate byte-perfect assembly repros by using `asm` blocks and ending in non-void functions with a `asm("ret");` followed by a `__builtin_unreachable();`

The relwithdebinfo build would have the function as `noreturn` and this would cascade into having ghidra be unable to analyze any calling functions.