### PR TITLE
project.py: portable libcmt member extraction (fix Windows ninja build)

### DIFF
--- a/tools/ar_extract.py
+++ b/tools/ar_extract.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Extract one member from a static library (.lib) to a specific output path.
+
+`llvm-ar p <archive> <member>` streams the named member's bytes to stdout; the
+natural shell redirect `> <out>` is not portable. Windows ninja runs rule
+commands without a shell, so both the `>` redirect and the quotes around the
+member name reach llvm-ar as literal arguments and the extraction fails
+("'>' was not found"). Doing the stream-and-write in Python behaves identically
+on every host, with no shell dependency.
+
+Usage: ar_extract.py <llvm-ar> <archive> <member> <out>
+"""
+import subprocess
+import sys
+
+
+def main(argv):
+    if len(argv) != 5:
+        sys.exit("usage: ar_extract.py <llvm-ar> <archive> <member> <out>")
+    ar, archive, member, out = argv[1:]
+    # `p` prints the named member's raw bytes to stdout; capture them as binary.
+    result = subprocess.run([ar, "p", archive, member], stdout=subprocess.PIPE)
+    if result.returncode != 0:
+        return result.returncode
+    with open(out, "wb") as handle:
+        handle.write(result.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/project.py
+++ b/tools/project.py
@@ -729,12 +729,16 @@ def generate_build_ninja(
     llvm_ar: Optional[Path] = None
     if config.static_libs and lld_link is not None:
         # llvm-ar ships alongside lld-link in the LLVM toolchain. Members carry
-        # Windows archive paths (e.g. ..\build\intel\mt_obj\util.obj); stream
-        # the exact member out (llvm-ar p needs the literal name).
+        # Windows archive paths (e.g. ..\build\intel\mt_obj\util.obj). ar_extract.py
+        # streams the exact member out via `llvm-ar p` and writes it to $out in
+        # Python, so the rule needs no shell redirect -- Windows ninja runs commands
+        # without a shell, which broke the old `p $in '$member' > $out` (the '>' and
+        # quotes reached llvm-ar literally).
         llvm_ar = lld_link.parent / f"llvm-ar{EXE}"
+        ar_extract = config.tools_dir / "ar_extract.py"
         n.rule(
             name="extract_lib_obj",
-            command=f"{llvm_ar} p $in '$member' > $out",
+            command=f"$python {ar_extract} {llvm_ar} $in $member $out",
             description="AR $out",
         )
         for lib_id, tag in config.static_libs.items():
@@ -1361,7 +1365,7 @@ def generate_build_ninja(
                         outputs=extracted,
                         rule="extract_lib_obj",
                         inputs=archive,
-                        implicit=[llvm_ar],
+                        implicit=[llvm_ar, config.tools_dir / "ar_extract.py"],
                         variables={"member": lib_member},
                     )
                 if obj.options["add_to_all"]:


### PR DESCRIPTION
The extract_lib_obj rule used `llvm-ar p $in '$member' > $out` -- a shell redirect with quotes around the member. Windows ninja runs rule commands without a shell, so the `>` and the quotes reach llvm-ar as literal arguments and extraction fails ("'>' was not found"; the quoted member "not found"). POSIX hosts (CI) use /bin/sh so it worked there, but the build was unbuildable on Windows.

Add tools/ar_extract.py -- a small portable wrapper that runs `llvm-ar p` and writes the captured bytes to the output in Python (no shell) -- and point the rule at it via $python. Verified: full `ninja all_source` now builds on Windows (util.obj extracts to a valid i386 COFF); behaviour is unchanged on POSIX.