### PR TITLE
Point2D::GetNormSq: byte-exact LINKED lift (BW1E142)

### DIFF
--- a/src/Lionhead/LH3DLib/development/LHPoint.h
+++ b/src/Lionhead/LH3DLib/development/LHPoint.h
@@ -40,9 +40,10 @@ struct Point2D
     // win1.41 00611330 mac 100e7550 Point2D::Normalize(void)
     float Normalize();
     // win1.41 006115f0 mac 1005ba40 Point2D::GetNormSq(void) const
-    float GetNormSq();
     // win1.41 0086fda0 mac inlined Point2D::GetNormSq(void) const copy
-    float GetNormSq();
+    // Defined inline in the header: the release emits it as an (un-ICF'd) COMDAT
+    // at both 0x006115F0 and 0x0086FDA0 and inlines it at many call sites.
+    float GetNormSq() { return x * x + y * y; }
     // win1.41 006159c0 mac inlined Point2D::operator==(const Point2D&)
     bool operator==(const Point2D* other);
     // win1.41 0086fd00 mac 10089260 Point2D::GetHeading(void) const


### PR DESCRIPTION
Squared 2D norm (x*x + y*y) - a self-contained leaf (no calls/branches/writes). The MSVC6 /O2 x87 schedule reproduces the original 20 bytes at 0x6115F0 exactly. First lift in a Lionhead SDK TU (LH3DLib).

MatchingFor(BW1E142): claimed for v1.42 only; other versions stay NonMatching.

Verified linked-not-carved by the empty-body differential (WSL): with the real body the bytes at 0x6115F0 equal the original; replacing the body changes those exact bytes at the same VA -> the .o is linked, not dtk-carved.

LHPoint.h: minimal repair so the unit compiles - drop the 3 duplicate fold-twin decls (operator=/DotProduct/GetNormSq copies share a signature) and fix 5 invalid 2-param member binary operators (* + -) to the correct 1-param form.