### PR TITLE
configure: Materialize local static libs at build/lib for sha check

### DIFF
--- a/config/BW1E142/symbols.txt
+++ b/config/BW1E142/symbols.txt
@@ -19304,6 +19304,7 @@ ___old_sbh_new_region = .text:0x007CF612; // type:function size:0x144 scope:glob
 ___old_sbh_release_region = .text:0x007CF756; // type:function size:0x56 scope:global
 ___old_sbh_decommit_pages = .text:0x007CF7AC; // type:function size:0xC2 scope:global
 ___old_sbh_find_block = .text:0x007CF86E; // type:function size:0x57 scope:global
+___old_sbh_free_block = .text:0x007CF8C5; // type:function size:0x45 scope:global
 ___old_sbh_alloc_block = .text:0x007CF90A; // type:function size:0x208 scope:global
 ___old_sbh_alloc_block_from_page = .text:0x007CFB12; // type:function size:0x124 scope:global
 ___old_sbh_resize_block = .text:0x007CFC36; // type:function size:0xA9 scope:global

--- a/tools/project.py
+++ b/tools/project.py
@@ -743,24 +743,32 @@ def generate_build_ninja(
             command=f"{llvm_ar} p $in '$member' > $out",
             description="AR $out",
         )
+        n.rule(
+            name="copy_lib",
+            command=f'$python -c "import shutil,sys;'
+            f'shutil.copyfile(sys.argv[1],sys.argv[2])" $in $out',
+            description="COPY $out",
+        )
         # Collect the libs that must be downloaded, grouped by package, so each
         # package's disc is fetched by a single download_tool edge (downloaded
         # once, all its members extracted) rather than once per lib.
         to_download: Dict[str, List[Path]] = {}
         for lib_id, package in config.static_libs.items():
+            # The .lib always lands at build/lib/<lib_id>.lib: it is both the
+            # member-extraction source and the sha-checked build artifact.
+            archive = config.build_dir / "lib" / f"{lib_id}.lib"
+            lib_archives[lib_id] = archive
             # Prefer a locally supplied lib (under <static_libs_path>/<package>)
-            # over the download: use it verbatim as a source input, so ninja
-            # never runs download_tool and the source disc is never fetched.
+            # over the download: copy it into place so ninja never runs
+            # download_tool and the source disc is never fetched.
             local = (
                 config.static_libs_path / package / f"{lib_id}.lib"
                 if config.static_libs_path is not None
                 else None
             )
             if local is not None and local.exists():
-                lib_archives[lib_id] = local
+                n.build(outputs=archive, rule="copy_lib", inputs=local)
                 continue
-            archive = config.build_dir / "lib" / f"{lib_id}.lib"
-            lib_archives[lib_id] = archive
             to_download.setdefault(package, []).append(archive)
         for package, archives in to_download.items():
             tag = config.static_lib_packages[package]


### PR DESCRIPTION
--static-libs-dir pointed member extraction at the supplied lib but never produced build/lib/<lib_id>.lib, which build.sha1 verifies. The check then failed (libcpmt.lib missing, libcmt.lib stale from cache).

Add a copy_lib rule so a local lib is copied into build/lib/<lib_id>.lib, making that path both the extraction source and the sha-checked artifact. The download fallback is unchanged.