### PR TITLE
Migrate two function implementations from existing mod

### DIFF
--- a/src/Black/AbodeInfo.h
+++ b/src/Black/AbodeInfo.h
@@ -8,6 +8,7 @@
 
 #include "MultiMapFixedInfo.h" /* For struct GMultiMapFixedInfo */
 #include "Name.h" /* For struct Name */
+#include "Lionhead/LHFile/ver3.0/LHFile.h" /* For LHFile */
 
 // Forward Declares
 
@@ -93,7 +94,12 @@ public:
     // BW1W120 00405a60 BW1M100 inlined GAbodeInfo::GetDescription(void)
     const char* GetDescription();
     // BW1W120 0042e520 BW1M100 inlined GAbodeInfo::LoadBinary(LHFile *)
-    void LoadBinary(LHFile* file);
+    void LoadBinary(LHFile* file)
+    {
+        file->GetSegmentData(&type, sizeof(type), -1);
+        SetInfoID();
+        file->GetSegmentData(&editorMesh, sizeof(editorMesh), -1);
+    }
 };
 static_assert(sizeof(GAbodeInfo) == 0x1c8, "Data type is of wrong size");
 

--- a/src/Black/Ball.h
+++ b/src/Black/Ball.h
@@ -74,12 +74,12 @@ public:
     // Static methods
 
     // BW1W120 00435b90 BW1M100 100b09f0 Ball::Create(MapCoords const &, GBallInfo const *, unsigned short, float, float)
-    static Ball* Create(Ball* this, const MapCoords* param_1, const GBallInfo* param_2, unsigned short param_3, float param_4, float param_5);
+    static Ball* Create(const MapCoords& param_1, const GBallInfo* param_2, unsigned short param_3, float param_4, float param_5);
 
     // Constructors
 
     // BW1W120 004359b0 BW1M100 100b0df0 Ball::Ball(MapCoords const &, GBallInfo const *)
-    Ball(const MapCoords* coords, const GBallInfo* info);
+    Ball(const MapCoords& coords, const GBallInfo* info);
 
     // Non-virtual methods
 

--- a/src/Black/BaseInfo.cpp
+++ b/src/Black/BaseInfo.cpp
@@ -1,0 +1,10 @@
+#include "BaseInfo.h" /* For struct GBaseInfo */
+
+#include "Game.h" /* For g_game */
+
+// Unknown if this function is inlined. Put in cpp file to avoid circular header dependency issues.
+void GBaseInfo::SetInfoID()
+{
+    index = GBaseInfo::info_count++;
+    Game::g_game->lists->base_infos.PushBack(this);
+}

--- a/src/Black/BaseInfo.h
+++ b/src/Black/BaseInfo.h
@@ -16,6 +16,9 @@ public:
     GBaseInfo* next; /* 0x8 */
     int index;
 
+    // BW1W120 0x00c58604
+    static uint32_t info_count;
+
     // Override methods
 
     // BW1W120 0042e600 BW1M100 10429820 GBaseInfo::_dt(void)

--- a/src/Black/BigForest.h
+++ b/src/Black/BigForest.h
@@ -41,7 +41,7 @@ public:
     // BW1W120 00438e10 BW1M100 100b25b0 BigForest::GetDebugText(void)
     virtual char* GetDebugText();
     // BW1W120 004394e0 BW1M100 100b2760 BigForest::Load(GameOSFile &)
-    virtual bool Load(GameOSFile* file);
+    virtual bool32_t Load(GameOSFile* file);
     // BW1W120 00439470 BW1M100 100b2840 BigForest::Save(GameOSFile &)
     virtual uint32_t Save(GameOSFile* param_1);
     // BW1W120 00438e00 BW1M100 100b2570 BigForest::GetSaveType(void)

--- a/src/Black/DancePathInfo.h
+++ b/src/Black/DancePathInfo.h
@@ -15,7 +15,7 @@ class DancePathInfo: public GameThing
 public:
     uint8_t field_0x14;
     uint8_t field_0x15[0x3];
-    uint8_t (*) field_0x18[0xc];
+    uint8_t (*field_0x18)[0xc];
     uint32_t field_0x1c;
 
     // Override methods

--- a/src/Black/Flock.h
+++ b/src/Black/Flock.h
@@ -12,6 +12,7 @@
 class Base;
 class CitadelHeart;
 class Creature;
+struct GFlockInfo;
 class GPlayer;
 class GameOSFile;
 class GameThing;
@@ -85,7 +86,7 @@ public:
     // Constructors
 
     // BW1W120 0052f780 BW1M100 100e6ec0 Flock::Flock(MapCoords const &, GFlockInfo const *, GPlayer *, unsigned long)
-    Flock(MapCoords* coords, GFlockInfo* info, GPlayer* player, uint32_t param_4);
+    Flock(const MapCoords& coords, const GFlockInfo* info, GPlayer* player, uint32_t param_4);
     // BW1W120 100e6be0 BW1M100 0052f950 Flock::Flock(Living*)
     Flock(Living* param_1);
 

--- a/src/Black/FootpathFinder.h
+++ b/src/Black/FootpathFinder.h
@@ -4,8 +4,8 @@
 #include <assert.h> /* For static_assert */
 #include <stdint.h> /* For uint32_t */
 
-#include <lhall/released/headers/RPHolder.h> /* For struct RPHolder */
-#include <lhall/released/headers/RPlan.h> /* For struct RPlan */
+#include <Lionhead/LHLib/ver5.0/RPHolder.h> /* For struct RPHolder */
+#include <Lionhead/LHLib/ver5.0/RPlan.h> /* For struct RPlan */
 
 #include "GameThing.h" /* For struct GameThing */
 

--- a/src/Black/Forest.h
+++ b/src/Black/Forest.h
@@ -4,6 +4,8 @@
 #include <assert.h> /* For static_assert */
 #include <stdint.h> /* For uint32_t, uint8_t */
 
+#include <Lionhead/LHLib/ver5.0/LHLinkedList.h> /* For struct LHLinkedList */
+
 #include "Container.h" /* For struct Container, struct ContainerVftable */
 #include "Tree.h" /* For struct Tree */
 
@@ -25,8 +27,8 @@ public:
     uint8_t field_0x30[0x10];
     uint32_t id; /* 0x40 */
     Forest* next;
-    LHLinkedList__Tree trees_0;
-    LHLinkedList__Tree trees_1; /* 0x50 */
+    LHLinkedList<Tree> trees_0;
+    LHLinkedList<Tree> trees_1; /* 0x50 */
 
     // Override methods
 
@@ -51,7 +53,7 @@ public:
     // BW1W120 00539b10 BW1M100 100ef7d0 Forest::GetDebugText(void)
     virtual char* GetDebugText();
     // BW1W120 0053b070 BW1M100 100ef950 Forest::Load(GameOSFile &)
-    virtual bool Load(GameOSFile* file);
+    virtual bool32_t Load(GameOSFile& file);
     // BW1W120 0053ae40 BW1M100 100efda0 Forest::Save(GameOSFile &)
     virtual uint32_t Save(GameOSFile* param_1);
     // BW1W120 00539b00 BW1M100 100ef790 Forest::GetSaveType(void)

--- a/src/Black/Game.h
+++ b/src/Black/Game.h
@@ -67,6 +67,9 @@ class Town;
 class GGame: public GameThing
 {
 public:
+    // BW1W120 00d0195c
+    static GGame* g_game;
+
     uint32_t field_0x14;
     GPlayer players[0x8];
     uint8_t field_0x5318[0x664];

--- a/src/Black/Game.h
+++ b/src/Black/Game.h
@@ -6,7 +6,7 @@
 
 #include <chlasm/Enum.h> /* For enum TRIBE_TYPE */
 #include <chlasm/LHKeyBoard.h> /* For enum LH_KEY */
-#include <lhall/released/headers/LHTimer.h> /* For struct LHTimer */
+#include <Lionhead/LHLib/ver5.0/LHTimer.h> /* For LHTimer */
 #include <Lionhead/LHLib/ver5.0/LHMouse.h> /* For enum LH_MOUSE_EVENT_TYPE */
 
 #include "CreatureDatabase.h" /* For struct CreatureDatabase */

--- a/src/Black/GroupBehaviour.h
+++ b/src/Black/GroupBehaviour.h
@@ -4,6 +4,8 @@
 #include <assert.h> /* For static_assert */
 #include <stdint.h> /* For uint32_t, uint8_t */
 
+#include <Lionhead/LHLib/ver5.0/LHDynamicStack.h> /* For LHDynamicStack */
+
 #include "DanceGroup.h" /* For enum DANCE_GROUP_ACTION_TYPE */
 #include "DancePathInfo.h" /* For struct DancePathInfo */
 #include "GameThing.h" /* For struct GameThing */
@@ -69,7 +71,7 @@ public:
     // BW1W120 00596700 BW1M100 100f90b0 GroupBehaviour::UpdateGroupBasedOnAction(DanceGroup *, DANCE_GROUP_ACTION_TYPE, DanceGroupActionArgument const &, unsigned long)
     virtual void UpdateGroupBasedOnAction(DanceGroup* dance_group, DANCE_GROUP_ACTION_TYPE action_type, const DanceGroupActionArgument* argument, uint32_t param_4);
     // BW1W120 00597300 BW1M100 100f8760 GroupBehaviour::AddAction(float, LHDynamicStack<Ul> &, DANCE_GROUP_ACTION_TYPE, DanceGroupActionArgument const &)
-    virtual void AddAction(float param_1, LHDynamicStack__Ul* stack, DANCE_GROUP_ACTION_TYPE action_type, const DanceGroupActionArgument* argument);
+    virtual void AddAction(float param_1, LHDynamicStack<uint32_t>& stack, DANCE_GROUP_ACTION_TYPE action_type, const DanceGroupActionArgument* argument);
     // BW1W120 00597270 BW1M100 100f8990 GroupBehaviour::AddAction(float, unsigned long, DANCE_GROUP_ACTION_TYPE, DanceGroupActionArgument const &)
     virtual void AddAction(float param_1, uint32_t param_2, DANCE_GROUP_ACTION_TYPE action_type, DanceGroupActionArgument* arguments);
     // BW1W120 005978e0 BW1M100 100f6eb0 GroupBehaviour::LoadDance(char const *)

--- a/src/Black/MobileObject.h
+++ b/src/Black/MobileObject.h
@@ -119,7 +119,7 @@ public:
     // BW1W120 00607aa0 BW1M100 103bbe00 MobileObject::CanBecomeAPhysicsObject(void)
     virtual bool CanBecomeAPhysicsObject();
     // BW1W120 00607410 BW1M100 103bcc90 MobileObject::AddToRoutePlan(RPHolder *, Creature *, int, void (*)(int, Point2D, float, int))
-    virtual void AddToRoutePlan(RPHolder* param_1, Creature* param_2, int param_3, void (__cdecl*)(int, Point2D, float, int) param_4);
+    virtual void AddToRoutePlan(RPHolder* param_1, Creature* param_2, int param_3, void (__cdecl* param_4)(int, Point2D, float, int));
     // BW1W120 00425b50 BW1M100 100ad9d0 MobileObject::GetTastiness(void)
     virtual uint32_t GetTastiness();
     // BW1W120 00607270 BW1M100 103bcd10 MobileObject::SaveObject(LHOSFile &, MapCoords const &)

--- a/src/Black/MobileStatic.h
+++ b/src/Black/MobileStatic.h
@@ -146,7 +146,7 @@ public:
     // BW1W120 00609010 BW1M100 103bf860 MobileStatic::CreatureMustAvoid(Creature *)
     virtual bool CreatureMustAvoid(Creature* param_1);
     // BW1W120 00608ac0 BW1M100 103c0450 MobileStatic::AddToRoutePlan(RPHolder *, Creature *, int, void (*)(int, Point2D, float, int))
-    virtual void AddToRoutePlan(RPHolder* param_1, Creature* param_2, int param_3, void (__cdecl*)(int, Point2D, float, int) param_4);
+    virtual void AddToRoutePlan(RPHolder* param_1, Creature* param_2, int param_3, void (__cdecl* param_4)(int, Point2D, float, int));
     // BW1W120 00439690 BW1M100 100b4420 MobileStatic::IsSolidToNewAbode(void)
     virtual uint32_t IsSolidToNewAbode();
     // BW1W120 00439660 BW1M100 100b4240 MobileStatic::GetTastiness(void)

--- a/src/Black/PlayerInfo.h
+++ b/src/Black/PlayerInfo.h
@@ -52,7 +52,7 @@ public:
     // BW1W120 0054be50 BW1M100 104e7bd0 GPlayerInfo::_dt(void)
     virtual ~GPlayerInfo();
     // BW1W120 0054b830 BW1M100 1058eb00 GPlayerInfo::GetBaseInfo(unsigned long &)
-    virtual GBaseInfo* GetBaseInfo(uint32_t* param_1);
+    virtual GBaseInfo* GetBaseInfo(uint32_t& param_1);
 };
 
 struct PlayerInfo

--- a/src/Black/Tree.h
+++ b/src/Black/Tree.h
@@ -164,7 +164,7 @@ public:
     // BW1W120 0074c0e0 BW1M100 10156590 Tree::CreatureMustAvoid(Creature *)
     virtual bool CreatureMustAvoid(Creature* param_1);
     // BW1W120 0074a180 BW1M100 10158cd0 Tree::AddToRoutePlan(RPHolder *, Creature *, int, void (*)(int, Point2D, float, int))
-    virtual void AddToRoutePlan(RPHolder* param_1, Creature* param_2, int param_3, void (__cdecl*)(int, Point2D, float, int) param_4);
+    virtual void AddToRoutePlan(RPHolder* param_1, Creature* param_2, int param_3, void (__cdecl* param_4)(int, Point2D, float, int));
     // BW1W120 0074a140 BW1M100 10158d40 Tree::GetRoutePlanRadius(Creature *)
     virtual float GetRoutePlanRadius(Creature* param_1);
     // BW1W120 0074b720 BW1M100 10157800 Tree::IsARootedObject(void)

--- a/src/Lionhead/LHFile/ver3.0/LHFile.h
+++ b/src/Lionhead/LHFile/ver3.0/LHFile.h
@@ -29,8 +29,8 @@ public:
     uint32_t field_0x38;
     uint32_t field_0x3c;
     uint32_t field_0x40;
-    FuncPtr(name='LHFile__custom_read_function', call_type='__cdecl', result='uint32_t', args=['void*', 'size_t', 'void*'], arg_labels=['param_0', 'param_1', 'param_2'], decorated_name='LHFile__custom_read_function', indirection_level=1) custom_read_function;
-    FuncPtr(name='LHFile__custom_set_file_pointer_function', call_type='__cdecl', result='uint32_t', args=['uint32_t', 'uint32_t', 'void*'], arg_labels=['param_0', 'param_1', 'param_2'], decorated_name='LHFile__custom_set_file_pointer_function', indirection_level=1) custom_set_file_pointer_function;
+    uint32_t (*custom_read_function)(void* data, size_t length, void* user_data); /* 0x44 */
+    uint32_t (*custom_set_file_pointer_function)(uint32_t distance_to_move, uint32_t move_method, void* user_data);
     void* custom_read_function_user_data;
     LH_FILE_MODE file_mode; /* 0x50 */
     bool segment_opened;

--- a/src/Lionhead/LHLib/ver5.0/LHDynamicStack.h
+++ b/src/Lionhead/LHLib/ver5.0/LHDynamicStack.h
@@ -1,0 +1,9 @@
+#ifndef BW1_DECOMP_LH_DYNAMIC_STACK_INCLUDED_H
+#define BW1_DECOMP_LH_DYNAMIC_STACK_INCLUDED_H
+
+template<typename T>
+class LHDynamicStack {
+public:
+};
+
+#endif /* BW1_DECOMP_LH_DYNAMIC_STACK_INCLUDED_H */

--- a/src/Lionhead/LHLib/ver5.0/LHMouse.h
+++ b/src/Lionhead/LHLib/ver5.0/LHMouse.h
@@ -98,7 +98,7 @@ struct LHSurface;
 struct LHMouse
 {
     LH_SCREEN_BUFFER screen_buffer; /* 0x0 */
-    FuncPtr(name='LHMouse__handler', call_type='__cdecl', result='bool', args=['void*', 'enum LH_MOUSE_EVENT_TYPE', 'uint32_t', 'uint32_t'], arg_labels=['param_0', 'param_1', 'param_2', 'param_3'], decorated_name='LHMouse__handler', indirection_level=1) handler;
+    bool(__cdecl* handler)(void*, LH_MOUSE_EVENT_TYPE, uint32_t, uint32_t);
     uint32_t field_0x8;
     bool32_t in_window;
     uint8_t field_0x10;

--- a/src/Lionhead/LHLib/ver5.0/LHScreen.h
+++ b/src/Lionhead/LHLib/ver5.0/LHScreen.h
@@ -9,12 +9,7 @@ enum LH_SCREEN_BUFFER
   LH_SCREEN_BUFFER_0x1 = 0x1,
   _LH_SCREEN_BUFFER_COUNT = 0x2
 };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpragma-pack"
-#pragma clang diagnostic ignored "-Wmacro-redefined"
-#pragma clang diagnostic ignored "-Wmissing-declarations"
 #include <ddraw.h> /* For IDirectDraw7, IDirectDrawClipper, IDirectDrawSurface7 */
-#pragma clang diagnostic pop
 #include <stdint.h> /* For int32_t, uint16_t, uint32_t, uint8_t */
 
 #include <Lionhead/LH3DLib/development/LHCoord.h> /* For struct LHCoord */

--- a/src/Lionhead/LHLib/ver5.0/LHTimer.h
+++ b/src/Lionhead/LHLib/ver5.0/LHTimer.h
@@ -1,0 +1,33 @@
+#ifndef BW1_DECOMP_LH_TIMER_INCLUDED_H
+#define BW1_DECOMP_LH_TIMER_INCLUDED_H
+
+#include <assert.h> /* For static_assert */
+#include <stdint.h> /* For uint32_t, uint8_t */
+
+struct LHTimer
+{
+    uint8_t field_0x0[0x100];
+    uint32_t tick_count; /* 0x100 */
+    int elapsed_time;
+    float speed_up_factor;
+    float speed_up_factor_2;
+
+    // Non-virtual methods
+
+    // win1.41 inlined mac 10001570 LHTimer::Running(void)
+    bool32_t Running();
+    // win1.41 inlined mac 10005790 LHTimer::Start(void)
+    void Start();
+    // win1.41 0043e9c0 mac 10001820 LHTimer::Stop(void)
+    void Stop();
+    // win1.41 0043eb70 mac 100056e0 LHTimer::MSeconds(void)
+    int MSeconds();
+    // win1.41 inlined mac 100017b0 LHTimer::GetSpeedUpFactor(void)
+    float GetSpeedUpFactor();
+    // win1.41 0043ebc0 mac 100016c0 LHTimer::SetSpeedUpFactor(float)
+    void SetSpeedUpFactor(float factor);
+    // win1.41 0054b850 mac 10005830 LHTimer::Reset(ulong)
+    void Reset(uint32_t value);
+};
+
+#endif /* BW1_DECOMP_LH_TIMER_INCLUDED_H */

--- a/src/Lionhead/LHLib/ver5.0/RPAvoid.h
+++ b/src/Lionhead/LHLib/ver5.0/RPAvoid.h
@@ -1,0 +1,22 @@
+#ifndef BW1_DECOMP_RP_AVOID_INCLUDED_H
+#define BW1_DECOMP_RP_AVOID_INCLUDED_H
+
+#include <assert.h> /* For static_assert */
+#include <stdint.h> /* For uint32_t */
+
+#include <Lionhead/LH3DLib/development/LHPoint.h> /* For Point2D */
+
+struct RPAvoid
+{
+    float field_0x0;
+    float field_0x4;
+    Point2D field_0x8;
+    float field_0x10;
+
+    // Non-virtual methods
+
+    // win1.41 008690a0 mac 100a8da0 RPAvoid::PointIsTotallyInside(Point2D const &, float)
+    uint32_t PointIsTotallyInside(const Point2D& param_1, float param_2);
+};
+
+#endif /* BW1_DECOMP_RP_AVOID_INCLUDED_H */

--- a/src/Lionhead/LHLib/ver5.0/RPHolder.h
+++ b/src/Lionhead/LHLib/ver5.0/RPHolder.h
@@ -1,0 +1,50 @@
+#ifndef BW1_DECOMP_RP_HOLDER_INCLUDED_H
+#define BW1_DECOMP_RP_HOLDER_INCLUDED_H
+
+#include <assert.h> /* For static_assert */
+#include <stdint.h> /* For uint32_t, uint8_t */
+
+#include <re_common.h> /* For struct vec2u16 */
+
+#include "RPAvoid.h" /* For struct RPAvoid */
+
+// Forward Declares
+
+struct Point2D;
+class RPFollow;
+
+struct RPHolder
+{
+    RPAvoid avoid_array[0x4000]; /* 0x0 */
+    int avoid_count; /* 0x50000 */
+    Point2D* field_0x50004;
+    Point2D* field_0x50008;
+    uint32_t field_0x5000c[0x4];
+    uint8_t field_0x5001c;
+    float field_0x50020;
+    RPFollow* field_0x50024;
+    vec2u16 field_0x50028[0x1000];
+    vec2u16 field_0x54028[0x4000];
+    uint32_t field_0x64028;
+
+    // Static methods
+
+    // win1.41 0083b300 mac 1061e7c4 RPHolder::InitialiseSystem(void (__cdecl *)(int, int, struct RPHolder *), void (__cdecl *)(struct RPHolder *))
+    static void InitialiseSystem(void (__cdecl* param_1)(int, int, RPHolder *), void (__cdecl* param_2)(RPHolder *));
+
+    // Constructors
+
+    // win1.41 0083b2e0 mac 1061b374 RPHolder::RPHolder(void)
+    RPHolder();
+
+    // Non-virtual methods
+
+    // win1.41 0083b330 mac 1061c58c RPHolder::Empty(void)
+    void Empty();
+    // win1.41 0083b860 mac 100ac020 RPHolder::GetSidePointOfStartObject(int, Point2D const &, Point2D &, int)
+    uint32_t GetSidePointOfStartObject(int param_1, Point2D* param_2, Point2D* param_3, int param_4);
+    // win1.41 0083bb60 mac 100ab580 RPHolder::GetFirstObject(Point2D const &, Point2D &, int, Point2D &, int &, float)
+    int GetFirstObject(Point2D* param_1, Point2D* param_2, int param_3, Point2D* param_4, int* param_5, float param_6);
+};
+
+#endif /* BW1_DECOMP_RP_HOLDER_INCLUDED_H */

--- a/src/Lionhead/LHLib/ver5.0/RPlan.h
+++ b/src/Lionhead/LHLib/ver5.0/RPlan.h
@@ -1,0 +1,63 @@
+#ifndef BW1_DECOMP_R_PLAN_INCLUDED_H
+#define BW1_DECOMP_R_PLAN_INCLUDED_H
+
+#include <assert.h> /* For static_assert */
+#include <stdint.h> /* For uint32_t */
+
+#include <lionhead/lh3dlib/development/LHPoint.h> /* For struct Point2D */
+
+// Forward Declares
+
+struct RPHolder;
+struct Route;
+struct VisitBlock;
+
+struct RPlan
+{
+    RPHolder* holder; /* 0x0 */
+    float field_0x4;
+    int field_0x8;
+    int field_0xc;
+    int field_0x10;
+    int field_0x14;
+    int field_0x18;
+    uint32_t field_0x1c;
+    uint32_t field_0x20;
+    Point2D field_0x24;
+    Point2D field_0x2c;
+    Point2D field_0x34;
+    float field_0x3c;
+    float field_0x40;
+    float field_0x44;
+    float field_0x48;
+    float field_0x4c;
+    uint32_t field_0x50;
+    uint32_t field_0x54;
+    VisitBlock* visit_blocks;
+    float field_0x5c;
+    Route* route_0x60;
+    uint32_t field_0x64;
+    Route* route_0x68;
+    Route* route_0x6c;
+    Route* route_0x70;
+
+    // Constructors
+
+    // win1.41 0086e0d0 mac 100aefe0 RPlan::RPlan(void)
+    RPlan();
+
+    // Non-virtual methods
+
+    // win1.41 0086e100 mac 100aee30 RPlan::FreeRoutes(void)
+    void FreeRoutes();
+    // win1.41 0086e200 mac 100aed70 RPlan::SetStart(Point2D const &, float, RPHolder *, int, int, int)
+    void SetStart(Point2D* param_1, float param_2, RPHolder* holder, int param_4, int param_5, int param_6);
+    // win1.41 0086e250 mac 100ae750 RPlan::SetDest(Point2D const &, float, float, float, int, int, float, int)
+    void SetDest(const Point2D* param_1, float param_2, float param_3, float param_4, int param_5, int param_6, float param_7, int param_8);
+    // win1.41 0086e9a0 mac 1061b3ec RPlan::GameTurnUpdate(int)
+    void GameTurnUpdate(int param_2);
+    // win1.41 0086e0f0 mac 100aef60 RPlan::~RPlan(void)
+    ~RPlan();
+};
+
+#endif /* BW1_DECOMP_R_PLAN_INCLUDED_H */


### PR DESCRIPTION
I had a development mod in which I detoured functions. In this process I did a lot of reverse engineering.

This PR brings two functions `GAbodeInfo::LoadBinary` and `GBaseInfo::SetInfoID` and fixes headers needed for those functions.