### PR TITLE
Update clang-format-action to version 4.18.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: jidicula/clang-format-action@v4.16.0
+    - uses: jidicula/clang-format-action@v4.18.0
       with:
         clang-format-version: '21'
         fallback-style: 'none'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,6 @@ name: lint
 
 on:
   pull_request:
-    paths:
-      - '**.hpp'
-      - '**.cpp'
-      - '**.h'
-      - '**.c'
-      - '**.clang-format'
   push:
     branches:
       - main


### PR DESCRIPTION
This version is supposed to run faster thanks to https://github.com/jidicula/clang-format-action/pull/281

This brings the time down from ~5 minutes to about 15 seconds.