### PR TITLE
Villager: parallel opus matching batch + skill/tooling

### DIFF
--- a/.claude/skills/villager-state-matching/CHEATSHEET.md
+++ b/.claude/skills/villager-state-matching/CHEATSHEET.md
@@ -1,4 +1,9 @@
-# MSVC 6.5 /O2 /Og idiom cheat-sheet — Villager campaign
+# MSVC 6.5 /O2 /Og idiom cheat-sheet — BW1 decomp (game-wide)
+
+This is **game-wide MSVC 6 codegen knowledge**, not Villager-specific. It was grown
+during the Villager campaign but every entry below is a property of the compiler /
+linker and applies to any BW1 TU. When you expand matching to another subsystem,
+read this first and keep appending — the idiom set is the compounding asset.
 
 Append-only. Entry format:
 
@@ -11,6 +16,82 @@ Diff signature: what you see in decomp-diff → what to write.
 Tag ledger entries that used one: `vsm.py log ... --idiom slug`.
 Seeded from AGENTS.md rules and the matched `Villager::DecideWhatToDo` session
 (0x7515c0); everything below is proven against the real compiler.
+
+---
+
+## Mangled-name decoder (MSVC 6, 32-bit)
+
+The `// BW1W120 <addr> BW1M100 <addr> <demangled>` comment is **ground truth for the
+signature**, but the demangling can be wrong/incomplete — decode the raw mangled
+symbol from `config/BW1W120/symbols.txt` yourself. Signature disputes (const, ref vs
+ptr, `bool` vs `bool32_t`, static/virtual) are settled here, not by guessing. This is
+the single most-reused lookup in the campaign; keep it handy.
+
+A member symbol is `?Name@Class@@` then `<access><cv><callconv><ret><args>Z`:
+
+| position | code → meaning |
+|---|---|
+| **access** | `Q`=public · `I`=protected · `A`=private · `U`=public **virtual** · `M`=protected virtual · `E`=private virtual · `S`=public **static** (no `this`, no cv, callconv follows directly) |
+| **cv** (non-static only) | `A`=none · `B`=**const** · `C`=volatile · `D`=const volatile |
+| **callconv** | `E`=`__thiscall` · `A`=`__cdecl` · `G`=`__stdcall` · `I`=`__fastcall` |
+| **return / arg types** | see below, in order: return type first, then each arg |
+
+Type codes (the ones that actually appear): `X`=void · `_N`=**bool** (1 byte) ·
+`D`=char `E`=unsigned char `C`=signed char · `F`=short `G`=unsigned short ·
+`H`=int `I`=**unsigned int** (this is what `bool32_t` mangles as) · `J`=long `K`=unsigned long ·
+`M`=**float** `N`=double · `PA`=pointer (`PAX`=void*, `PAUFoo@@`=`Foo*`, `PAVFoo@@`=`Foo*` for class) ·
+`PB`=pointer-to-const · `AA`=**reference** (`AAUFoo@@`=`Foo&`) · `AB`=**const reference** (`ABUFoo@@`=`const Foo&`) ·
+`U`=struct `V`=class `W4`=enum · a `?A` prefix on the return marks a returned UDT/enum by value.
+
+Worked examples (all validated against the binary this campaign):
+- `?GetTopState@Living@@QBE?AW4VILLAGER_STATES@@XZ` → `public`,`const`,`__thiscall`, returns enum `VILLAGER_STATES`, `void` args ⇒ `VILLAGER_STATES GetTopState() const;`
+- `?IsDancing@Living@@UAEIXZ` → public **virtual**, non-const, returns `I`=unsigned int ⇒ `virtual bool32_t IsDancing();` (**not** `bool` — that would be `_N`)
+- `?MakeHomeless@Villager@@QAE_NXZ` → `_N` return ⇒ `bool MakeHomeless();` (**not** `bool32_t`)
+- `?CheckForClearArea@Villager@@QAEIABUMapCoords@@M@Z` → `ABUMapCoords`=`const MapCoords&`, `M`=float ⇒ `bool32_t CheckForClearArea(const MapCoords&, float);` (AGENTS Rule 1: ref, not ptr)
+- `?SetupAfterTapOnAbode@Villager@@QAEXAAUMapCoords@@W4VILLAGER_STATES@@@Z` → `AAUMapCoords`=`MapCoords&` (non-const ref), returns void.
+
+**`bool` (`_N`, 1 byte) vs `bool32_t` (`I`, 4 bytes)** decides `al` vs `eax` codegen and
+is a frequent 1-instruction miss — read the mangling before touching a bool return.
+
+---
+
+## Systemic blockers — recognise, then DEFER (dispatcher-owned)
+
+Six independent Villager workers converged on the same five ceilings. When you hit one,
+you are done with that function: get the semantics correct, add a `// TODO:`, log
+`deferred` with the specifics, and move on. Chasing these past the 12-cycle cap produces
+fakematches (negative progress). They resolve at the campaign level, not per-function.
+
+1. **Scheduler / register-pressure tie-breaks** — semantics are right, only a spill/push/
+   vtable-load floats by 1–2 positions. Idioms: [`save-across-call-spill`], [`retbuf-arg-order`],
+   [`bool-return-full-eax-epilogue`], [`cmp-mem-rhs-spill`], [`tail-duplication-asymmetry`],
+   [`setup-addreaction-field-sched`]. A toy can match while the full TU doesn't (register
+   pressure differs). Revisit only when a *neighbour with the same shape* matches and reveals it.
+
+2. **Return-type truths you cannot override** — the mangled signature is ground truth;
+   never add/remove a return type to move bytes. Idioms: [`void-call-eax-probed-by-caller`]
+   (a `QAEX` void whose caller reads `eax`), [`fpu-leak-void-return`] (void/uint body leaks
+   ST0), [`bool-return-mask-needs-callee-defined`] (caller's `and eax,0xff` vanishes once
+   the in-TU bool callee is *defined*). Often unblocked by defining a callee, not by editing the caller.
+
+3. **Base-class vtable / layout bugs** — `call [reg+0xNNN]` differs only in the displacement,
+   or a member is read at the wrong offset. The header hierarchy has extra/missing virtuals or
+   a base placed at the wrong offset (seen in Creche, MultiMapFixed, Abode/GameThingWithPos).
+   VERIFY with a raw `.rdata` vtable dump ([`vtable-slot-verify`]) — never trust Ghidra alone —
+   then defer with the exact byte delta. **Do not edit another unit's class header to "fix" layout**;
+   that is dispatcher work with cross-TU blast radius.
+
+4. **Missing / unnamed symbols** — a global at an absolute address or an `fn_00xxxxxx` helper
+   that has no name in `symbols.txt`. You cannot reference it by name, so the call/load reloc
+   can't match. Defer with `--notes "symbol: <addr> needs naming"`; the dispatcher adds it.
+
+5. **Link artifacts (not real mismatches, not fakematchable)** — `/OPT:ICF` folds two
+   byte-identical functions onto one address (e.g. a `Villager` reaction folded onto a
+   `PuzzleHorse` method): writing a cast to force it is a fakematch — leave it. `__real@…`
+   COMDAT float pooling and phantom abs32 relocs ([`phantom-abs32-reloc`]) are byte-identical
+   after link — verify with `objdump -r` on both objects and ignore.
+
+---
 
 ### ptr-vs-ref
 Rule: the mangled name in the `// BW1W120` comment encodes the true signature — `Type const &` there beats `Type*` in the header (AGENTS.md Rule 1).
@@ -95,3 +176,31 @@ Diff signature: n/a yet (not reproduced in our build) — this is a research not
 ### setstate-eq-1
 Rule: `SetCurrentAndDestinationState(CURRENT, dest) == 1` (vtable slot 0x8dc) is the standard state-entry predicate; the `== 1` (not `!= 0`) matches the `dec;neg;sbb;inc` normalization the compiler emits and the existing LivingReaction precedent.
 Diff signature: target calls `[vtbl+0x8dc]` then `dec eax;neg eax;sbb eax,eax;inc eax` → write `... == 1`.
+
+### arg-bool-local-defer
+Rule: when a call passes a comparison/bool as one arg and a struct member's address (`obj.member` by const-ref) as another, MSVC6 evaluates args right-to-left and computes the address LAST (into the just-freed reg). Writing the comparison inline lets the scheduler hoist the address `lea` early into a spare reg (edx) → sticks ~92%. Materialising the comparison into a named `int` local first (`int isX = (Field == K); f(obj.member, isX);`) defers the `lea` to after the bool push, reusing ecx — matching.
+Diff signature: only diff is a `lea reg,[this+off]` that appears BEFORE `sete`/`setz` in ours but AFTER the `push` of the bool in target (and reg is edx vs ecx) → pull the bool comparison out into an `int` local.
+
+### fpu-leak-void-return (OPEN — don't burn cycles)
+Rule: several VillagerFood methods are mangled `void`/`unsigned int` (`X`/`I` return) yet the target's body ends by leaving a `float` result of a callee (e.g. `GetLifeDesireFromLife`, `GetAmountOfFoodToEat`, `POWER`) sitting in ST0 with NO `fstp st(0)` to discard it — the original source apparently relied on that leaked FPU value (UB / return-type mismatch in the original). Our faithful `void` body always emits the extra `fstp st(0)` (or, for an `unsigned int` return, an `__ftol` conversion) that the target omits, costing exactly one trailing instruction. Not reproducible from a clean `void`/`uint` source: declaring the true float return changes the mangled name (breaks symbols.txt), and MSVC6 won't emit a bare leak from a void statement call. Confirmed on `GetDesireForLife` (extra `fstp st(0)`), family also flagged on `GetDesireToPickupFood`, `EatFoodHeld`, `EatFood`, `GetFoodFromHome`.
+Diff signature: only diff is a `>` extra `fstp st(0)` (void return) or an extra `call __ftol`/`fistp` (uint return) immediately after a float-returning callee, right before `pop`/`ret` → get correct semantics, `// TODO:`, defer. Revisit only if a neighbor reveals a source shape that legally leaks ST0.
+
+### bool-return-mask-needs-callee-defined
+Rule: `unsigned int Caller() { ... return BoolCallee(); ... }` where `BoolCallee` is mangled `_N` (real C++ `bool`, 1-byte). If `BoolCallee`'s DEFINITION is visible in the same TU, MSVC6 knows the return is a clean 0/1 and emits NO widening — the `bool` in eax is returned as-is. If `BoolCallee` is only an extern DECLARATION (callee not yet implemented in the TU), MSVC6 conservatively inserts `and eax,0xff` to zero-extend. So a caller can be stuck one instruction short (`> and eax,0xff`) purely because its in-TU bool callee is still a stub/missing. Not a caller-side source-shape bug.
+Diff signature: only diff is a `>` extra `and eax,0xff` (or `movzx eax,al`) right after a `call <BoolCallee>` whose result is returned, and that callee is `missing`/stubbed in the same unit → the caller will match automatically once the bool callee is DEFINED in the TU. Defer the caller with a note pointing at the callee; don't try to rewrite the caller's return.
+
+### argeval-named-local-before-const-push
+Rule: for `f(GetX(), CONST)` where GetX() is a call and CONST is an immediate, the target often materialises GetX() FIRST (call, keep in eax) then `push CONST; push eax`. Naive `f(GetX(), CONST)` may push CONST before the call. Binding the call result to a named local — `T* x = GetX(); f(x, CONST);` — forces call-then-push-const-then-push-x, matching, without spilling (stays in eax).
+Diff signature: target `call GetX; push CONST; push eax`, ours `push CONST; call GetX; push eax` → introduce the named local.
+
+### cmp-imm-exact-boundary
+Rule: MSVC6 encodes an integer relational compare with the EXACT literal you write — it does NOT canonicalize `> K` to `>= K+1` or `< K` to `<= K-1`. To match a target's `cmp eax, IMM; j<cc>`, pick the source operator+enum whose literal equals IMM. E.g. target `cmp 0x2f; jl` (i.e. `< 47`) came from `state >= 47` (enum FORESTER_MOVE_TO_FOREST=47), NOT `state > 46`; target `cmp 0x32; jle` came from `state <= 50`, NOT `state < 51`. Semantically-equal but off-by-one literals mismatch.
+Diff signature: `~` on the immediate of a `cmp eax, {0xNN}` plus an extra/missing `jle`/`jl` pair → rewrite the boundary using the enum member whose value == the target immediate, flipping `>`↔`>=` / `<`↔`<=` accordingly.
+
+### tailcall-virtual-jmp
+Rule: `return this->SomeVirtual(args);` in tail position where SomeVirtual has the same calling convention/args as the enclosing method compiles to `mov eax,[ecx]; jmp [eax+slot]` (a vtable-dispatched tail jump, no call/ret). Just write the natural virtual call as the sole `return` statement.
+Diff signature: target body is `mov eax,[ecx]; jmp dword ptr [eax+0xNNN]` (size ~8B) → `return VirtualMethod(...)`.
+
+### setup-addreaction-field-sched (OPEN — don't burn cycles)
+Rule: the `Villager::SetupReactTo*` family bodies are `AddReaction(reaction, STATE); field_0xbc = target;` (or field-first). Semantics are trivial and correct, but MSVC6's scheduler places the virtual-call vtable load (`mov eax,[esi]`/`mov eax,[ecx]`) at a position that our naive source can't reproduce for the BARE two-statement form: target loads the vtable BEFORE the constant `push STATE` (or, for field-first-with-`this`, reloads it AFTER the field store), ours does the opposite → sticks ~83% (or ~43% for the `field_0xbc=this` self-store shape). Guarded variants that have EXTRA instructions before the call (e.g. SetupFleeFromPredator's `GetFinalState()` early-out) DO reach 100%, because the added register pressure shifts the schedule. So the fix is not a local rewrite — it's whole-function context. field-first with `field=param_1` (not `this`) fares better (~83%) than `field=this` (~43%).
+Diff signature: only diffs are a `push <imm>` (the STATE constant) and a `mov <reg>,[<this>]` (vtable load) floating past each other around one virtual call, everything else identical → correct semantics, `// TODO:` if desired, `vsm.py log --result improved`. Don't exceed the cap chasing it; revisit only if a neighboring Setup* with the same shape reveals the trigger.

--- a/.claude/skills/villager-state-matching/SKILL.md
+++ b/.claude/skills/villager-state-matching/SKILL.md
@@ -30,6 +30,10 @@ python3 .claude/skills/villager-state-matching/vsm.py next --unit VillagerStates
 # 3. write the body in the unit's .cpp at the stub marked  // BW1W120 00769830
 #    (if the file has no stub yet, add the function in ADDRESS ORDER with that comment;
 #     the declaration already exists in src/Black/Villager.h)
+#    STUB COMMENT: copy the ENTIRE `// BW1W120 <w> BW1M100 <m> <sig>` line VERBATIM from
+#    the header — never retype the BW1M100 (Mac) address. Retyping corrupts the Mac
+#    address map (9 such copy errors were found and fixed in the pilot). Validate with:
+#      python3 tools/check_stub_addrs.py src/Black/<Unit>.cpp
 
 # 4. build ONLY your object (never bare `ninja` in the loop — seconds vs minutes)
 ninja build/BW1W120/src/Black/VillagerStates.o
@@ -114,3 +118,21 @@ A unit is done when overview mode shows every symbol `match`, including:
 
 Then the **dispatcher** (not you): full `ninja` + `ninja baseline`/`changes_all`
 regression pair, flip the TU to `Matching` in `configure.py`, commit.
+
+## Generalizing to other subsystems (Creature, Town, World, …)
+
+This skill is the template for matching *any* BW1 subsystem, not just Villager. What is
+reusable as-is vs. what to re-scope per campaign:
+
+- **Reusable game-wide (do not rewrite):** `CHEATSHEET.md` (MSVC6 codegen idioms +
+  mangled-name decoder + systemic-blocker taxonomy), the per-function loop
+  (Ghidra → write → build one `.o` → decomp-diff → iterate), the 12-cycle cap /
+  defer-is-success discipline, the diff-triage table, and `tools/check_stub_addrs.py`.
+- **Re-scope per campaign:** `vsm.py` is currently hard-scoped to the Villager objdiff
+  units (`index`/`next` rank within that set). For a new subsystem, point the same queue
+  machinery at that subsystem's units (or generalize the unit list), keep one ledger,
+  and reuse the claim protocol so parallel workers don't collide.
+- **Dispatcher handoff is the same everywhere:** workers own single-unit source shapes;
+  struct/vtable **layout**, **symbol naming** in `symbols.txt`, shared-header return-type
+  decisions, and TU-status flips in `configure.py` are dispatcher-owned. Workers log the
+  need and defer — see the systemic-blocker taxonomy in `CHEATSHEET.md`.

--- a/src/Black/Living.h
+++ b/src/Black/Living.h
@@ -390,7 +390,7 @@ public:
 	// BW1W120 005ed2b0 BW1M100 10380650 Living::DebugShowTime(unsigned long, unsigned char, unsigned char)
 	virtual uint32_t DebugShowTime(uint32_t param_1, uint8_t param_2, uint8_t param_3);
 	// BW1W120 005ecc10 BW1M100 10084310 Living::IsDancing(void)
-	virtual bool IsDancing();
+	virtual bool32_t IsDancing();
 	// BW1W120 00473e90 BW1M100 101e3580 Living::IsInterestedInFoodObject(Object *)
 	virtual bool IsInterestedInFoodObject(Object* param_1);
 	// BW1W120 00417080 BW1M100 1012fa20 Living::IsInterestedInWoodObject(Object *)
@@ -740,8 +740,8 @@ public:
 	                                         VILLAGER_STATES param_3);
 	// BW1W120 005f2640 BW1M100 10385e00 Living::GotoPickupBallReaction(void)
 	uint32_t GotoPickupBallReaction();
-	// BW1W120 005f27f0 BW1M100 10056110 Living::GetTopState(void)
-	VILLAGER_STATES GetTopState();
+	// BW1W120 005f27f0 BW1M100 10056110 Living::GetTopState(void) const
+	VILLAGER_STATES GetTopState() const;
 	// BW1W120 005f2800 BW1M100 1038a340 Living::SetupMoveToObject(Object *, unsigned char)
 	bool SetupMoveToObject(Object* param_1, unsigned char param_2);
 	// BW1W120 005f2830 BW1M100 10029240 Living::SetupMoveToPos(MapCoords const &, unsigned char)

--- a/src/Black/MapCoords.h
+++ b/src/Black/MapCoords.h
@@ -83,7 +83,7 @@ struct MapCoords
 	// BW1W120 00603340 BW1M100 1006a370 MapCoords::Set(LHPoint const &)
 	MapCoords* Set(const LHPoint* point);
 	// BW1W120 00603430 BW1M100 10049b80 MapCoords::ToMap(void) const
-	MapCell* ToMap();
+	MapCell* ToMap() const;
 	// BW1W120 006034b0 BW1M100 1002cb50 MapCoords::GetFirstObjectFixed(void) const
 	Object* GetFirstObjectFixed();
 	// BW1W120 006034d0 BW1M100 1002c570 MapCoords::GetFirstIterator(void) const

--- a/src/Black/Town.h
+++ b/src/Black/Town.h
@@ -285,7 +285,7 @@ public:
 	// BW1W120 0073cf00 BW1M100 10551920 Town::IsBuildingSiteValid(BuildingSite *)
 	bool32_t IsBuildingSiteValid(BuildingSite* param_1);
 	// BW1W120 0073cf60 BW1M100 10097910 Town::GetBestBuildingSite(MapCoords const &, int)
-	bool32_t GetBestBuildingSite(const MapCoords* param_1, int param_2);
+	bool32_t GetBestBuildingSite(const MapCoords& param_1, int param_2);
 	// BW1W120 0073d080 BW1M100 105516a0 Town::AddPlanned(PlannedMultiMapFixed *)
 	void AddPlanned(PlannedMultiMapFixed* planned);
 	// BW1W120 0073d0d0 BW1M100 10551530 Town::RemovePlanned(PlannedMultiMapFixed *)

--- a/src/Black/Villager.cpp
+++ b/src/Black/Villager.cpp
@@ -241,13 +241,13 @@ void Villager::PickupWood(short param_1, unsigned char param_2) {}
 // BW1W120 007514d0
 int Villager::GetFoodCapacity()
 {
-	return 0;
+	return ((const GVillagerInfo*)info)->MaxFoodCarried - ResourceHeld[RESOURCE_TYPE_FOOD];
 }
 
 // BW1W120 007514f0
 int Villager::GetWoodCapacity()
 {
-	return 0;
+	return ((const GVillagerInfo*)info)->MaxWoodCarried - ResourceHeld[RESOURCE_TYPE_WOOD];
 }
 
 // BW1W120 00751510
@@ -404,7 +404,7 @@ void Villager::PopFromPrevious() {}
 // BW1W120 00751ea0
 Football* Villager::GetFootball()
 {
-	return NULL;
+	return football;
 }
 
 // BW1W120 00751ee0
@@ -422,7 +422,13 @@ Town* Villager::GetTown()
 // BW1W120 00751f10
 StoragePit* Villager::GetStoragePit()
 {
-	return NULL;
+	if (GetTown() != NULL)
+	{
+		StoragePit* storagePit = GetTown()->GetStoragePit();
+		if (storagePit != NULL)
+			return storagePit;
+	}
+	return (StoragePit*)GetAbode();
 }
 
 // BW1W120 00751f40
@@ -464,7 +470,7 @@ uint32_t Villager::CanPauseForASecond(VILLAGER_STATES state)
 // BW1W120 00752160
 Abode* Villager::GetAbode()
 {
-	return NULL;
+	return home;
 }
 
 // BW1W120 007521b0

--- a/src/Black/Villager.h
+++ b/src/Black/Villager.h
@@ -964,7 +964,7 @@ public:
 	// BW1W120 00758f60 BW1M100 105751d0 Villager::ReenterBuildingState(void)
 	bool32_t ReenterBuildingState();
 	// BW1W120 007590a0 BW1M100 10574e20 Villager::CheckForClearArea(MapCoords const &, float)
-	bool32_t CheckForClearArea(const MapCoords* param_1, float param_2);
+	bool32_t CheckForClearArea(const MapCoords& param_1, float param_2);
 	// BW1W120 007592e0 BW1M100 10574d90 Villager::ArriveAtPushObject(void)
 	bool32_t ArriveAtPushObject();
 	// BW1W120 00759330 BW1M100 10574c20 Villager::CheckSatisfyToBuild(void)
@@ -1346,9 +1346,9 @@ public:
 	// BW1W120 007611f0 BW1M100 105874c0 Villager::HomeDeleted(void)
 	void HomeDeleted();
 	// BW1W120 00761220 BW1M100 10587440 Villager::MakeHomeless(void)
-	bool32_t MakeHomeless();
+	bool MakeHomeless();
 	// BW1W120 00761240 BW1M100 10587220 Villager::MakeHomelessNoStateChange(void)
-	bool32_t MakeHomelessNoStateChange();
+	bool MakeHomelessNoStateChange();
 	// BW1W120 00761320 BW1M100 10587160 Villager::HomelessStart(void)
 	bool32_t HomelessStart();
 	// BW1W120 00761360 BW1M100 10586fd0 Villager::CheckHomelessMoveIntoAbode(void)
@@ -1356,7 +1356,7 @@ public:
 	// BW1W120 007613f0 BW1M100 10586f90 Villager::VillagerGossips(void)
 	bool32_t VillagerGossips();
 	// BW1W120 00761400 BW1M100 10586ed0 Villager::SetupAfterTapOnAbode(MapCoords &, VILLAGER_STATES)
-	void SetupAfterTapOnAbode(MapCoords* param_1, VILLAGER_STATES param_2);
+	void SetupAfterTapOnAbode(MapCoords& param_1, VILLAGER_STATES param_2);
 	// BW1W120 00761440 BW1M100 10586e70 Villager::AfterTapOnAbode(void)
 	bool32_t AfterTapOnAbode();
 	// BW1W120 00761460 BW1M100 100955e0 Villager::CheckSatisfyRelaxation(void)

--- a/src/Black/VillagerChild.cpp
+++ b/src/Black/VillagerChild.cpp
@@ -7,6 +7,13 @@
 #include "VillagerInfo.h"
 
 // BW1W120 007579f0 BW1M100 10573ed0 Villager::ChildGotoCreche(void)
+// TODO: 94.7% match. Two blocking diffs, both outside this unit:
+// (1) retbuf-arg-order (OPEN): target pushes the constant state 0x71 before materialising
+//     GetDoorPos' hidden retbuf temp; our build hoists the retbuf lea/push ahead of the push 0x71.
+// (2) vtable-slot: our build calls Creche vtable slot 0x8a4 for GetDoorPos, but the real Creche
+//     vtable (??_7Creche@@6B@ @0x8D16C4) has GetDoorPos (=MultiMapFixed::GetDoorPos, 0x52e370) at
+//     slot 0x864 -- 0x40 (16 slots) earlier. The Creche/MultiMapFixed header hierarchy declares
+//     ~16 extra virtuals before GetDoorPos. Layout fix belongs to the dispatcher.
 uint32_t Villager::ChildGotoCreche()
 {
 	if (GetTown() != NULL)
@@ -45,7 +52,7 @@ uint32_t Villager::CheckChild()
 	return 0;
 }
 
-// BW1W120 00757ec0 BW1M100 105744c0 Villager::ChildDecideWhatToDo(void)
+// BW1W120 00757ec0 BW1M100 10573a80 Villager::ChildDecideWhatToDo(void)
 bool32_t Villager::ChildDecideWhatToDo()
 {
 	if (CheckChild() != true && ChildAtCreche() != true && ChildGotoCreche() == false)
@@ -93,15 +100,16 @@ bool32_t Villager::IsMotherAlive()
 }
 
 // BW1W120 00758080 BW1M100 105734a0 Villager::MoveVillagerToAbode(Abode*)
-// TODO: 59.3% match. Target reaches a SINGLE shared ForceMoveVillagerToAbode call site from
-// both branches (jg to a common tail), but duplicates the early-return epilogue in each branch;
-// our build does the reverse -- it inlines/duplicates the ForceMoveVillagerToAbode call into
-// both branches and shares only the final epilogue. Tried a shared `int roomLeft` local computed
-// in each branch with a single trailing `if (roomLeft > 0) ForceMoveVillagerToAbode(abode);`
-// (regressed to 56.0%, still duplicated) and the plain nested if/else with the call written
-// inside each branch (49.8%, wrong register assignment too). This early-return form gives the
-// closest match (correct edi=this/esi=abode register assignment) but the call-site sharing is
-// an unresolved compiler tail-duplication asymmetry.
+// TODO: 59.3% match. ROOT CAUSE (confirmed via target objdump): this is the void-call-eax-probed-
+// by-caller OPEN research case (cheatsheet names this exact function). The mangling QAEX makes it
+// void, yet the target body loads a return value on every path -- `xor eax,eax` (=0) in BOTH
+// bail-out branches at 0x840/0x850 and `mov eax,1` at the shared action tail 0x85f -- which its
+// caller CheckNeedNewAbode reads via `cmp eax,1`. A legal void function cannot emit those eax
+// loads (MSVC6 errors on `return 1;` from void and dead-eliminates a 0/1 local under /O2), so the
+// remaining 40% (the missing xor/mov eax + the resulting shared-action/duplicated-bailout tail
+// shape) cannot be closed without solving that research idiom. The control-flow structure below
+// is the closest legal void shape (correct edi=this/esi=abode assignment). Cause still unknown --
+// look for a matched neighbour with the identical void-eax shape before attempting again.
 void Villager::MoveVillagerToAbode(Abode* abode)
 {
 	if (IsChild())
@@ -122,15 +130,15 @@ void Villager::MoveVillagerToAbode(Abode* abode)
 }
 
 // BW1W120 007580d0 BW1M100 105733f0 Villager::MakeChildOrphaned(Villager *)
-uint32_t Villager::MakeChildOrphaned(Villager* param_1)
+uint32_t Villager::MakeChildOrphaned(Villager* dead_villager)
 {
 	// TODO: 91% match. Target loads `mother` into eax and compares directly against the
-	// [esp+8] stack slot (`cmp eax,[esp+8]`); our build additionally spills param_1 into ecx
+	// [esp+8] stack slot (`cmp eax,[esp+8]`); our build additionally spills dead_villager into ecx
 	// first (`mov ecx,[esp+8]; cmp eax,ecx`). Tried swapping comparison operand order and an
-	// early-return (`if (mother != param_1) return 0;`) restructuring -- both regressed further
+	// early-return (`if (mother != dead_villager) return 0;`) restructuring -- both regressed further
 	// (86%/58%). Also `test eax,eax` (target) vs `test al,al` (ours) after IsVillagerAvailable(),
 	// same family as the bool-return-full-eax-epilogue open idiom.
-	if (mother == param_1)
+	if (mother == dead_villager)
 	{
 		if (IsVillagerAvailable())
 		{

--- a/src/Black/VillagerCivic.cpp
+++ b/src/Black/VillagerCivic.cpp
@@ -1,0 +1,134 @@
+#include "Villager.h"
+
+#include "BuildingSite.h"
+#include "GameThingWithPos.h"
+#include "MultiMapFixed.h"
+#include "Town.h"
+#include "VillagerInfo.h"
+
+// BW1W120 00758180 BW1M100 10096f90 Villager::CheckNeededForCivic(void)
+bool32_t Villager::CheckNeededForCivic()
+{
+	if (GetTown() != NULL && CheckNeededForTownDesire() == 1)
+		return true;
+	return false;
+}
+
+// BW1W120 007584b0 BW1M100 10576950 Villager::SetupBuildingObject(BuildingSite *)
+bool32_t Villager::SetupBuildingObject(BuildingSite* building_site)
+{
+	if (GetTown() != NULL)
+	{
+		MultiMapFixed* building = building_site->GetBuilding();
+		if (building != NULL)
+		{
+			// TODO: MultiMapFixed vtable layout bug (dispatcher): IsRepaired/IsBuilt land at
+			// +0x8b4/+0x8b8 here but the binary has them at +0x88c/+0x890 -- 10 extra virtual
+			// slots (0x28) declared before them in MultiMapFixed.h. Also prologue reg-save
+			// (push ebx/esi/edi) scheduling differs. Body logic verified correct (84.5%).
+			if (building->IsBuilt() == 1 && building->IsRepaired())
+				return false;
+			if (CheckForClearArea(((GameThingWithPos*)building)->coords, building_site->GetClearAreaRadius()) == 1)
+				return true;
+			if (SetupGetBuildingSupplies(building_site) == 1)
+				return true;
+		}
+	}
+	return false;
+}
+
+// BW1W120 00758960 BW1M100 10576080 Villager::GotoWorkshopForBuildingMaterials(BuildingSite *)
+bool32_t Villager::GotoWorkshopForBuildingMaterials(BuildingSite* building_site)
+{
+	if (GetTown() != NULL)
+		GetTown()->IsBuildingSiteValid(building_site);
+	return false;
+}
+
+// BW1W120 00758e20 BW1M100 10575700 Villager::GetWoodUsedPerBuild(void)
+float Villager::GetWoodUsedPerBuild()
+{
+	return ((const GVillagerInfo*)info)->WoodUsedPerBuildCycle;
+}
+
+// BW1W120 00758e30 BW1M100 10098500 Villager::CheckSatisfyAbodesDesire(void)
+bool32_t Villager::CheckSatisfyAbodesDesire()
+{
+	if (CheckNeededForBuilding() == 1)
+		return true;
+	if (GetTown()->field_0x5e4 == 0)
+	{
+		GetTown()->field_0x5e4 = 1;
+		if (GetTown()->RequestANewAbode(ABODE_TYPE_LIVING_QUARTERS) == 1 && CheckNeededForBuilding() == 1)
+			return true;
+	}
+	return false;
+}
+
+// BW1W120 00758e90 BW1M100 105755c0 Villager::CheckSatisfyCivicBuildings(void)
+bool32_t Villager::CheckSatisfyCivicBuildings()
+{
+	if (CheckNeededForBuilding() == 1)
+		return true;
+	if (GetTown()->field_0x5e4 == 0)
+	{
+		GetTown()->field_0x5e4 = 1;
+		if (GetTown()->RequestBestPlanned() == 1 && CheckNeededForBuilding() == 1)
+			return true;
+	}
+	return false;
+}
+
+// BW1W120 00758ef0 BW1M100 10575580 Villager::ArrivesAtRockForWood(void)
+bool32_t Villager::ArrivesAtRockForWood()
+{
+	return true;
+}
+
+// BW1W120 00759330 BW1M100 10574c20 Villager::CheckSatisfyToBuild(void)
+bool32_t Villager::CheckSatisfyToBuild()
+{
+	Town* town = GetTown();
+	if (town != NULL)
+	{
+		int           isDisciple = (DiscipleType == VILLAGER_DISCIPLE_BUILDER);
+		BuildingSite* site = (BuildingSite*)town->GetBestBuildingSite(((GameThingWithPos*)this)->coords, isDisciple);
+		if (site != NULL && SetupBuildingObject(site) == 1)
+			return true;
+	}
+	return false;
+}
+
+// BW1W120 00759370 BW1M100 10574ad0 Villager::CheckSatisfyToRepair(void)
+bool32_t Villager::CheckSatisfyToRepair()
+{
+	Town* town = GetTown();
+	if (town != NULL)
+	{
+		BuildingSite* site = (BuildingSite*)town->GetBestRepairBuildingSite();
+		if (site != NULL && SetupBuildingObject(site) == 1)
+			return true;
+	}
+	return false;
+}
+
+// BW1W120 007595e0 BW1M100 10574610 Villager::CheckForScaffoldForBuildingSite(BuildingSite *)
+uint32_t Villager::CheckForScaffoldForBuildingSite(BuildingSite* param_1)
+{
+	return 0x2b;
+}
+
+// BW1W120 007595f0 BW1M100 105745d0 Villager::IsScaffoldValid(void)
+bool32_t Villager::IsScaffoldValid()
+{
+	// TODO: target emits narrow `xor al,al` (byte) but this uint-mangled (?..@@QAEIXZ)
+	// function constant-folds `return false;` to `xor eax,eax` no matter the phrasing
+	// (tried `0 != 0`, bool local). Mirror of CHEATSHEET bool-return-full-eax-epilogue.
+	return false;
+}
+
+// BW1W120 00759600 BW1M100 10574580 Villager::ExitBringScaffoldToBuildingSite(unsigned char)
+bool32_t Villager::ExitBringScaffoldToBuildingSite(unsigned char param_1)
+{
+	return true;
+}

--- a/src/Black/VillagerFood.cpp
+++ b/src/Black/VillagerFood.cpp
@@ -5,27 +5,39 @@
 #include "VillagerInfo.h"
 
 // BW1W120 0075b940
+// TODO: 46% — blocked on a cross-unit Rule 2 (hidden-retbuf) signature fix I can't make.
+// The true structure (from the target asm) is:
+//     if (Flags & 4) {
+//         MapCoords pos = FindPosOutsideAbode(NULL);           // hidden retbuf + Abode*=NULL
+//         SetupMoveToWithHug(pos, VILLAGER_STATE_SHOW_POISONED);
+//     }
+//     PlayAnimThenSetState(0xa3, 1);   // runs on BOTH paths (if-block FALLS THROUGH, no return)
+//     return true;
+// FindPosOutsideAbode's call site pushes TWO stack args — a NULL Abode* and the address of a
+// 12-byte MapCoords local (the retbuf `lea eax,[esp+8]; push eax`) — so per AGENTS.md Rule 2 its
+// real signature is `MapCoords FindPosOutsideAbode(Abode*)` (returns MapCoords by value), NOT the
+// current `void FindPosOutsideAbode(Abode*)`. Fixing that needs edits to Villager.h AND the stub
+// definition in Villager.cpp:678 (`void Villager::FindPosOutsideAbode(Abode*) {}`), which is
+// ANOTHER unit — dispatcher-owned. Once FindPosOutsideAbode returns MapCoords, the body above
+// should match. Left as-is (early-return in the if-block) until then to keep it compiling.
 bool Villager::ShowPoisoned()
 {
 	if (Flags & 4)
 	{
-		// TODO: FindPosOutsideAbode's declared signature (void(Abode*)) doesn't match the
-		// call site here - the target pushes TWO stack args (a NULL Abode* plus the address of
-		// a 12-byte local reserved on ShowPoisoned's own stack frame) suggesting a hidden
-		// MapCoords out-param that the header/symbols.txt doesn't currently show. Cross-unit
-		// (FindPosOutsideAbode lives in another TU) - not mine to fix. Deferred.
 		FindPosOutsideAbode(NULL);
-		return true; // placeholder - real target also calls SetupMoveToWithHug with the found pos
+		return true; // placeholder - real target falls through to PlayAnimThenSetState
 	}
 	PlayAnimThenSetState(0xa3, 1);
 	return true;
 }
 
-// TODO: void return per mangled name (?POWER_f_@@YAXMI@Z) is suspicious for a free cdecl
-// function - the compiled target leaves its result on the FPU stack (ST0) without popping,
-// and its only caller (GetDesireForFood) relies on that value as if POWER_f_ returned float.
-// Also the second (unsigned int) parameter is never read from the stack in the target; the
-// loop trip count is a hardcoded immediate 2. See idiom fpu-leak-void-return in CHEATSHEET.md.
+// TODO: 86.7% — the real symbol is ?POWER@@YGMM@Z (float __stdcall POWER(float)); it returns
+// its float result in ST0 (no leak issue here). The loop trip count is a hardcoded immediate 2,
+// modelled via the POWER<2> explicit specialization. Only residual diff: the loop body emits
+// `fmul st,[esp+4]` (long-latency) BEFORE `dec eax` in our build but AFTER it in the target,
+// even though the source order is `--i; result *= clamped;` (matches Ghidra). Scheduler
+// tie-break: the independent fmul is hoisted ahead of the counter decrement. No source shape
+// found to force dec-before-fmul without adding a fake dependency.
 template <int T> float __stdcall POWER(float base);
 template <> float __stdcall POWER<2>(float base);
 
@@ -42,10 +54,16 @@ bool32_t Villager::CheckHungryAtHome()
 }
 
 // BW1W120 0075bb00
-// TODO: mangled return is unsigned int (?GetDesireToPickupFood@Villager@@QAEIXZ) but the target
-// body computes and returns a FLOAT via the FPU (ST0) on both paths, never touching EAX - same
-// fpu-leak family as POWER_f_/EatFoodHeld/GetFoodFromHome. Declared bool32_t to keep the mangled
-// name matching symbols.txt; body below is semantically faithful but won't byte-match.
+// TODO: 51% — RETURN-TYPE CONTRADICTION (needs human/dispatcher). symbols.txt records this as
+// ?GetDesireToPickupFood@Villager@@QAEIXZ (unsigned int, `I`), so the header keeps bool32_t to
+// match. But the target body returns a FLOAT via ST0 on BOTH paths and never touches EAX:
+//   - held >= required : `fld [0.0f]; add esp,8; ret`   (returns 0.0f on ST0)
+//   - else             : `1.0 - held/required` left on ST0, NO __ftol
+// A faithful uint body can't reproduce this: the early-out becomes `xor eax,eax` (int 0) and the
+// compute path adds `call __ftol`. To byte-match, the function would have to be DECLARED float
+// (mangled `M`), which contradicts the recorded `I` symbol — either symbols.txt is wrong or the
+// original is UB (float returned from an unsigned-int-declared function). Deferred for a human to
+// decide the true signature; can't touch symbols.txt. Same fpu-leak family as POWER/EatFoodHeld.
 bool32_t Villager::GetDesireToPickupFood()
 {
 	const GVillagerInfo* villagerInfo = (const GVillagerInfo*)info;
@@ -64,10 +82,12 @@ template <> float __stdcall POWER<2>(float base)
 {
 	float clamped = (base < 1.0f) ? base : 1.0f;
 	float result = clamped;
-	for (int i = 0; i < 2; ++i)
+	int   i = 2;
+	do
 	{
+		--i;
 		result *= clamped;
-	};
+	} while (i != 0);
 	return 1.0f - result;
 }
 
@@ -80,17 +100,24 @@ void Villager::GetDesireForLife()
 }
 
 // BW1W120 0075bbc0
-float Villager::GetLifeDesireFromLife(float param_1)
+float Villager::GetLifeDesireFromLife(float life)
 {
 	const GVillagerInfo* villagerInfo = (const GVillagerInfo*)info;
-	float minLife = (villagerInfo->DamageThresholdToGoHome < param_1) ? villagerInfo->DamageThresholdToGoHome : param_1;
-	float t = (param_1 - minLife) / (1.0f - villagerInfo->DamageThresholdToGoHome);
+	float minLife = (villagerInfo->DamageThresholdToGoHome < life) ? villagerInfo->DamageThresholdToGoHome : life;
+	float t = (life - minLife) / (1.0f - villagerInfo->DamageThresholdToGoHome);
 	return 1.0f - t * t;
 }
 
 // BW1W120 0075bc00
 uint32_t Villager::GetAmountOfFoodRequiredForMeal()
 {
+	// TODO: 83.3% — pure scheduler tie-break. Target emits
+	//   test eax,eax; setle dl; pop esi; dec edx; and eax,edx
+	// i.e. `pop esi` is scheduled between setle and dec. Our build with the
+	// correct compare (test/setle, from `<= 0` / `> 0`) always schedules
+	// `dec edx` before `pop esi`; the only source shape that moves pop earlier
+	// (`< 1`) changes the compare to `cmp eax,1; setl` (wrong). Not a source
+	// shape issue — c2.dll scheduler tie-break (save-across-call-spill family).
 	int required = GetAmountOfFoodToEat() - ResourceHeld[RESOURCE_TYPE_FOOD];
 	return required > 0 ? required : 0;
 }
@@ -98,7 +125,8 @@ uint32_t Villager::GetAmountOfFoodRequiredForMeal()
 // BW1W120 0075bc20
 uint32_t Villager::GetAmountOfFoodToEat()
 {
-	float foodWanted = GetDesireForFood() * ((const GVillagerInfo*)info)->FoodReqiredForDinner;
+	const GVillagerInfo* villagerInfo = (const GVillagerInfo*)info;
+	float                foodWanted = GetDesireForFood() * villagerInfo->FoodReqiredForDinner;
 	if (GetTown())
 	{
 		float scarcity = GetTown()->desire.field_0x118[TOWN_DESIRE_INFO_FOR_FOOD];
@@ -106,12 +134,24 @@ uint32_t Villager::GetAmountOfFoodToEat()
 			scarcity = 0.0f;
 		else if (scarcity > 1.0f)
 			scarcity = 1.0f;
+		// TODO: 97.3% — two residual diffs:
+		//  (1) target's 0.3 constant is __real@3e999999 (one ULP BELOW 0.3f, whose
+		//      bits are 3e99999a). No evidence-based literal reproduces 3e999999;
+		//      likely a truncated double->float in the original source.
+		//  (2) scheduler tie-break: target emits `mov edx,[esi]` (GetTown vtable
+		//      load) before `mov [esp+0xc],0`; ours emits it after.
 		return (uint32_t)((1.0f - scarcity * 0.3f) * foodWanted);
 	}
 	return (uint32_t)foodWanted;
 }
 
 // BW1W120 0075bf00
+// TODO: 91.7% — only diff is a `> and eax,0xff` after the ChangeStateToFindFoodToEat call.
+// ChangeStateToFindFoodToEat is `_N` (real C++ bool); returning it as unsigned int widens the
+// byte. In the original TU ChangeStateToFindFoodToEat is DEFINED (0x0075b990, same unit), so
+// MSVC6 sees the clean 0/1 bool and elides the mask. Our build only has an extern decl (callee
+// still `missing`) so it masks conservatively. This will match automatically once
+// ChangeStateToFindFoodToEat is implemented in this unit. See bool-return-mask-needs-callee-defined.
 uint32_t Villager::CheckSatisfyOwnFoodDesire()
 {
 	if (IsHungry())
@@ -120,17 +160,24 @@ uint32_t Villager::CheckSatisfyOwnFoodDesire()
 }
 
 // BW1W120 0075bf20
-// TODO: mangled return is unsigned int (?EatFoodHeld@Villager@@QAEIXZ) but the target falls
-// through to "fld [this->food]" with no int conversion (no call to __ftol) before ret - same
-// fpu-leak family as GetDesireToPickupFood/POWER_f_. Declared uint32_t to keep the mangled name
-// matching symbols.txt; body below is semantically faithful but won't byte-match the epilogue.
+// TODO: 87.5% — three residual diffs, all scheduler/fpu-leak, not source-shape:
+//  (1) trailing `fld [this->food]` returns food as a leaked float; ours adds `call __ftol`
+//      to honor the `unsigned int` (?EatFoodHeld@Villager@@QAEIXZ) return. fpu-leak-void-return
+//      family (see CHEATSHEET.md) — can't leak from a uint-returning body.
+//  (2) the (float)foodToEat conversion block (fild qword/fstp [esp+8]) schedules early in ours,
+//      after the ResourceHeld int setup in target — scheduler tie-break.
+//  (3) DropFood arg: target emits `mov ecx,esi; push eax`, ours `push eax; mov ecx,esi`.
 uint32_t Villager::EatFoodHeld()
 {
-	float amountToEat = GetAmountOfFoodToEat();
-	if (amountToEat > (float)ResourceHeld[RESOURCE_TYPE_FOOD])
+	uint32_t foodToEat = GetAmountOfFoodToEat();
+	float    foodToEatF = (float)foodToEat;
+	float    amountToEat;
+	if (foodToEatF < (float)ResourceHeld[RESOURCE_TYPE_FOOD])
+		amountToEat = foodToEatF;
+	else
 		amountToEat = (float)ResourceHeld[RESOURCE_TYPE_FOOD];
 	DropFood((uint16_t)amountToEat);
-	food += amountToEat / (float)GetAmountOfFoodToEat() * ((const GVillagerInfo*)info)->FoodNurishmentMultiplier;
+	food += amountToEat / foodToEatF * ((const GVillagerInfo*)info)->FoodNurishmentMultiplier;
 	if (food < 0.0f)
 		food = 0.0f;
 	else if (food > 1.0f)
@@ -143,27 +190,45 @@ uint32_t Villager::EatFoodHeld()
 // BW1W120 0075c000
 uint32_t Villager::EatFood()
 {
-	// TODO: target discards EatFoodHeld's result via 'fstp st(0)' (fpu-leak-void-return family);
-	// ours computes a real int so there's nothing to discard. Also target computes the ternary
-	// below starting from a byte (neg al) then widens to eax (sbb/and/add eax) - exact source
-	// shape not found within budget.
+	// TODO: 71% — three residual diffs, none cleanly fixable from source:
+	//  (1) target discards EatFoodHeld's leaked float via `fstp st(0)`; our EatFoodHeld returns a
+	//      real int (uint mangling forces __ftol), so there's nothing to discard. Downstream of
+	//      the EatFoodHeld fpu-leak — resolves only when EatFoodHeld byte-matches.
+	//  (2) branchless ternary width: target does `neg al` (byte condition) then `sbb eax,eax;
+	//      and eax,0x31; add eax,0xa3` (dword result) — a width change mid-expression. Every
+	//      source phrasing tried keeps a single width (all-byte with the cond cast, all the
+	//      other way with a result cast); the byte-cond+dword-result mix wasn't reproduced.
+	//  (3) scheduler: target pushes the `1` arg and loads `this` (mov ecx,esi) AFTER the
+	//      IsPoisoned call; ours hoists `push 1` before it.
+	//  NAMING: 0xa3/0xd4 are VILLAGER_STATE_DECIDE_WHAT_TO_DO / VILLAGER_STATE_SHOW_POISONED
+	//  (PlayAnimThenSetState's uchar param is the state to enter, per matched neighbours in
+	//  VillagerHome.cpp and Villager.cpp's state table). Left as literals pending human sign-off
+	//  on the anim-vs-state naming of this parameter.
 	EatFoodHeld();
 	PlayAnimThenSetState((uint8_t)IsPoisoned() ? 0xd4 : 0xa3, 1);
 	return 1;
 }
 
 // BW1W120 0075c040
-// TODO: mangled return is unsigned int (?GetFoodFromHome@Villager@@QAEIK@Z) but the target
-// never sets EAX on either path (early-out or fallthrough after PickupFood) - relies on
-// whatever PickupFood happens to leave in EAX (UB in the original source). Same fpu-leak /
-// no-explicit-return family; see CHEATSHEET.md.
-bool32_t Villager::GetFoodFromHome(unsigned long param_1)
+// TODO: 77.8% — three residual diffs:
+//  (1) mangled return is unsigned int (?GetFoodFromHome@Villager@@QAEIK@Z) but the target
+//      never sets EAX on either path (null early-out via `je 0x7a4`, or fallthrough after the
+//      void PickupFood) — it returns whatever's leaked in EAX (original-source UB). We can't
+//      reproduce: MSVC6 rejects a no-return body with C4716 (hard error), so `return 0;` stays,
+//      costing one trailing `xor eax,eax`. no-explicit-return family.
+//  (2) ternary result register: target keeps `amount` in ECX (param_1 is already loaded to ECX
+//      for the compare and reused), emitting `jb` + fallthrough; ours puts it in EAX with an
+//      inverted `jae` + `mov eax,ecx; jmp`. Regalloc tie-break — the `amount = param_1; if(...)`
+//      if-form is WORSE (62.5%, spills param_1 to a callee-saved reg via ebx).
+//  (3) GetResourceFrom result arg to PickupFood: target `mov ecx,edi; push eax`, ours reversed.
+bool32_t Villager::GetFoodFromHome(unsigned long food_amount)
 {
 	Abode* abode = GetAbode();
 	if (abode != NULL)
 	{
-		uint32_t available = abode->GetResource(RESOURCE_TYPE_FOOD);
-		uint32_t amount = (param_1 < available) ? param_1 : available;
+		uint32_t amount = (food_amount < abode->GetResource(RESOURCE_TYPE_FOOD))
+		                      ? food_amount
+		                      : abode->GetResource(RESOURCE_TYPE_FOOD);
 		PickupFood((int16_t)GetResourceFrom(abode, RESOURCE_TYPE_FOOD, (int16_t)amount));
 	}
 	return 0;
@@ -172,10 +237,17 @@ bool32_t Villager::GetFoodFromHome(unsigned long param_1)
 // BW1W120 0075c090
 uint32_t Villager::EatFoodAtHome()
 {
-	int required = GetAmountOfFoodToEat() - ResourceHeld[RESOURCE_TYPE_FOOD];
+	int16_t held = ResourceHeld[RESOURCE_TYPE_FOOD];
+	int     required = GetAmountOfFoodToEat() - held;
 	if (required > 0)
 		GetFoodFromHome(required);
 	EatFoodHeld();
+	// TODO: residual diffs are the same deferred families as EatFood: EatFoodHeld leaks a float
+	// on ST0 that the target discards with `fstp st(0)` (our uint-returning EatFoodHeld has
+	// nothing to discard), and the branchless ternary below uses a byte condition (neg al) with a
+	// dword result (sbb/and/add eax) that no source phrasing reproduces. 0xd4/0x26 =
+	// VILLAGER_STATE_SHOW_POISONED / VILLAGER_STATE_AT_HOME (SetTopState arg) — literal pending
+	// human sign-off on the naming.
 	SetTopState(IsPoisoned() ? 0xd4 : 0x26);
 	return 1;
 }

--- a/src/Black/VillagerFootball.cpp
+++ b/src/Black/VillagerFootball.cpp
@@ -1,0 +1,136 @@
+#include "Villager.h"
+
+#include "Football.h"
+#include "Object.h"
+
+// BW1W120 0075d130 Villager::AssignFootballSubState(void)
+void Villager::AssignFootballSubState()
+{
+	switch ((uint8_t)GetFinalState())
+	{
+	case VILLAGER_STATE_FOOTBALL_ATTACKER:
+		AssignFootballAttackerSubState();
+		break;
+	case VILLAGER_STATE_FOOTBALL_GOALIE:
+		AssignFootballGoalieSubState();
+		break;
+	case VILLAGER_STATE_FOOTBALL_DEFENDER:
+		AssignFootballDefenderSubState();
+		break;
+	}
+}
+
+// BW1W120 0075ddc0 Villager::FootballAttackerLobNearGoalPriority(Football *)
+float Villager::FootballAttackerLobNearGoalPriority(Football* param_1)
+{
+	return 0.0;
+}
+
+// BW1W120 0075def0 Villager::FootballAttackerGoToBallPriority(Football *)
+float Villager::FootballAttackerGoToBallPriority(Football* param_1)
+{
+	return 0.0;
+}
+
+// BW1W120 0075e370 Villager::FootballDefenderClearProcess(Football *)
+void Villager::FootballDefenderClearProcess(Football* football)
+{
+	FootballDefenderSaveProcess(football);
+}
+
+// BW1W120 0075e990 Villager::FootballDefenderGoToBallPriority(Football *)
+float Villager::FootballDefenderGoToBallPriority(Football* param_1)
+{
+	return 0.0;
+}
+
+// BW1W120 0075e9a0 Villager::FootballDefenderGoHomePriority(Football *)
+float Villager::FootballDefenderGoHomePriority(Football* param_1)
+{
+	return FootballAttackerGoHomePriority(param_1);
+}
+
+// BW1W120 0075e9b0 Villager::FootballDefenderIdlePriority(Football *)
+float Villager::FootballDefenderIdlePriority(Football* param_1)
+{
+	return 1.0f - FootballDefenderGoHomePriority(param_1);
+}
+
+// BW1W120 0075ec50 Villager::FootballGoalieClearProcess(Football *)
+void Villager::FootballGoalieClearProcess(Football* football)
+{
+	FootballGoalieSaveProcess(football);
+}
+
+// BW1W120 0075ee00 Villager::FootballGoalieIdleProcess(Football *)
+void Villager::FootballGoalieIdleProcess(Football* football)
+{
+	FootballGoalieLookProcess(football);
+}
+
+// BW1W120 0075f020 Villager::FootballGoalieGoToBallPriority(Football *)
+float Villager::FootballGoalieGoToBallPriority(Football* param_1)
+{
+	return 0.0;
+}
+
+// BW1W120 0075f030 Villager::FootballGoalieGoHomePriority(Football *)
+float Villager::FootballGoalieGoHomePriority(Football* param_1)
+{
+	return FootballAttackerGoHomePriority(param_1);
+}
+
+// BW1W120 0075f040 Villager::FootballGoalieIdlePriority(Football *)
+float Villager::FootballGoalieIdlePriority(Football* param_1)
+{
+	return 1.0f - FootballGoalieGoHomePriority(param_1);
+}
+
+// BW1W120 0075f060 Villager::FootballGoaliePassPriority(Football *)
+float Villager::FootballGoaliePassPriority(Football* param_1)
+{
+	return FootballDefenderPassPriority(param_1);
+}
+
+// BW1W120 0075f070 Villager::FootballerIsTouchingBallPrecondition(Football *)
+bool Villager::FootballerIsTouchingBallPrecondition(Football* param_1)
+{
+	return IsTouching((Object*)param_1->GetBall(), GetHeight());
+}
+
+// BW1W120 0075f0a0 Villager::FootballerIsNotTouchingBallPrecondition(Football *)
+bool Villager::FootballerIsNotTouchingBallPrecondition(Football* param_1)
+{
+	return !IsTouching((Object*)param_1->GetBall(), GetHeight());
+}
+
+// BW1W120 0075f270 Villager::StartMoveToPickUpBallForDeadBall(void)
+bool32_t Villager::StartMoveToPickUpBallForDeadBall()
+{
+	// TODO: block-ordering tie-break. Semantics correct but MSVC6 lays out
+	// [cond][body][ret0] while target is [cond][ret0][body] (target jumps to the
+	// body via `jne`, ret0 is fallthrough). Tried &&, ||-early-return and nested-if
+	// forms — all produce identical [body][ret0] layout. ~9.6% (pure reorder).
+	if (GetFootball() != NULL && GetFootball()->GetBall() != NULL)
+	{
+		StartMoveToObject((Object*)GetFootball()->GetBall(), VILLAGER_STATE_ARRIVED_AT_PICK_UP_BALL_FOR_DEAD_BALL);
+		return 1;
+	}
+	return 0;
+}
+
+// BW1W120 0075f2c0 Villager::ArrivedAtPickUpBallForDeadBall(void)
+bool32_t Villager::ArrivedAtPickUpBallForDeadBall()
+{
+	Football* football = GetFootball();
+	LookAtObject(football, 2);
+	SetTopState(VILLAGER_STATE_ARRIVED_AT_PUT_DOWN_BALL_FOR_DEAD_BALL_START);
+	return 1;
+}
+
+// BW1W120 0075f2f0 Villager::ArrivedAtPutDownBallForDeadBallStart(void)
+bool32_t Villager::ArrivedAtPutDownBallForDeadBallStart()
+{
+	PlayAnimThenSetState(VILLAGER_STATE_ARRIVED_AT_PUT_DOWN_BALL_FOR_DEAD_BALL_END, 1);
+	return 1;
+}

--- a/src/Black/VillagerHome.cpp
+++ b/src/Black/VillagerHome.cpp
@@ -3,10 +3,13 @@
 #include "chlasm/GStates.h"
 
 #include "VillagerInfo.h"
+#include "VillagerStateTableInfo.h"
 #include "Abode.h"
 #include "Town.h"
 
-// BW1W120 0075ff80 BW1M100 10003330 Villager::CheckNeededForSomething(void)
+extern GVillagerStateTableInfo g_GVillagerStateTableInfos[VILLAGER_STATE_LAST_STATE];
+
+// BW1W120 0075ff80 BW1M100 1000a8c0 Villager::CheckNeededForSomething(void)
 bool32_t Villager::CheckNeededForSomething()
 {
 	if (GetAbode() == NULL)
@@ -17,6 +20,12 @@ bool32_t Villager::CheckNeededForSomething()
 		}
 	}
 	return CheckNeededForSpecial() == 1;
+}
+
+// BW1W120 00760000 BW1M100 10589480 Villager::NothingToDo(void)
+bool32_t Villager::NothingToDo()
+{
+	return true;
 }
 
 // BW1W120 00760010 BW1M100 10096ee0 Villager::CheckNeededForSpecial(void)
@@ -33,7 +42,211 @@ bool32_t Villager::CheckNeededForSpecial()
 	return CheckSatisfyOwnDesire(((const GVillagerInfo*)info)->OwnDesireThreshold) == 1;
 }
 
-// BW1W120 00761360 BW1M100 10092350 Villager::CheckHomelessMoveIntoAbode(void)
+// BW1W120 00760240 BW1M100 105892c0 Villager::CheckIllAtHome(void)
+bool32_t Villager::CheckIllAtHome()
+{
+	return false;
+}
+
+// BW1W120 00760250 BW1M100 10589160 Villager::GoHomeDropResource(void)
+bool32_t Villager::GoHomeDropResource()
+{
+	// TODO: 87.5% - target lays out the GotoStoragePit tail-jmp block before the
+	// GoHome one; our build orders them the other way (semantics identical).
+	// Block-ordering tie-break, unaffected by if/else vs &&/|| phrasing.
+	if (ResourceHeld[RESOURCE_TYPE_FOOD] != 0 || ResourceHeld[RESOURCE_TYPE_WOOD] != 0)
+	{
+		return GotoStoragePitForDropOff();
+	}
+	return GoHome();
+}
+
+// BW1W120 00760270 BW1M100 1009edb0 Villager::GoHome(void)
+bool32_t Villager::GoHome()
+{
+	return DoGoingHome(VILLAGER_STATE_ARRIVES_HOME, VILLAGER_STATE_SLEEP_IN_TENT);
+}
+
+// BW1W120 00760b10 BW1M100 10004a80 Villager::AtHome(void)
+bool32_t Villager::AtHome()
+{
+	HomeDecideWhatToDo();
+	return true;
+}
+
+// BW1W120 00760b20 BW1M100 10588720 Villager::SitsDownToDinner(void)
+bool32_t Villager::SitsDownToDinner()
+{
+	return true;
+}
+
+// BW1W120 00760b30 BW1M100 10003aa0 Villager::GotoBedAtHome(void)
+bool32_t Villager::GotoBedAtHome()
+{
+	SetTopState(VILLAGER_STATE_SLEEPING_AT_HOME);
+	TurnsUntilNextStateChange = (int16_t)((const GVillagerInfo*)info)->RestAtHomeTime;
+	return true;
+}
+
+// BW1W120 00760c80 BW1M100 10588200 Villager::CheckGetPregnantAtHome(void)
+bool32_t Villager::CheckGetPregnantAtHome()
+{
+	bool32_t r = WillHousewifeGetPregnant(NULL);
+	if (r != 0)
+	{
+		r = HousewifeGetsPregnant(NULL);
+	}
+	return r;
+}
+
+// BW1W120 00760d70 BW1M100 10023200 Villager::SleepingAtHome(void)
+bool32_t Villager::SleepingAtHome()
+{
+	if (GetTown() != NULL)
+	{
+		TurnsUntilNextStateChange--;
+		if (TurnsUntilNextStateChange == 0)
+		{
+			if (DoSleeping(1.0f) == 0)
+			{
+				SetTopState(VILLAGER_STATE_AT_HOME);
+			}
+		}
+	}
+	return true;
+}
+
+// BW1W120 00760e50 BW1M100 10587ee0 Villager::WakeUpAtHome(void)
+bool32_t Villager::WakeUpAtHome()
+{
+	return GoHome();
+}
+
+// BW1W120 00760f50 BW1M100 10587c50 Villager::StopHavingSex(void)
+bool32_t Villager::StopHavingSex()
+{
+	if (Flags & 4)
+	{
+		return GoHome();
+	}
+	SetTopState(VILLAGER_STATE_DECIDE_WHAT_TO_DO);
+	return true;
+}
+
+// BW1W120 00760f80 BW1M100 10587c10 Villager::StartHavingSexAtHome(void)
+bool32_t Villager::StartHavingSexAtHome()
+{
+	return true;
+}
+
+// BW1W120 00761010 BW1M100 10587a80 Villager::HavingSexAtHome(void)
+bool32_t Villager::HavingSexAtHome()
+{
+	return true;
+}
+
+// BW1W120 00761020 BW1M100 10587a40 Villager::StopHavingSexAtHome(void)
+bool32_t Villager::StopHavingSexAtHome()
+{
+	return true;
+}
+
+// BW1W120 00761030 BW1M100 10587a00 Villager::WaitForDinner(void)
+bool32_t Villager::WaitForDinner()
+{
+	return true;
+}
+
+// BW1W120 00761070 BW1M100 105878e0 Villager::IsAvailableForSex(void)
+bool32_t Villager::IsAvailableForSex()
+{
+	if (GetVillagerAvailableState() & 1)
+	{
+		return IsSexuallyActive();
+	}
+	return 0;
+}
+
+// BW1W120 00761090 BW1M100 10587810 Villager::IsSexuallyActive(void)
+bool32_t Villager::IsSexuallyActive()
+{
+	const GVillagerInfo* vi = (const GVillagerInfo*)info;
+	if (GetAge() >= vi->StartHavingSexAge)
+	{
+		// TODO: 90.9% - only the prologue `push edi` placement differs (target
+		// schedules it after the first vtable load); scheduler tie-break.
+		const GVillagerInfo* vi2 = (const GVillagerInfo*)info;
+		if (GetAge() < vi2->StopHavingSexAge)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+// BW1W120 00761180 BW1M100 10587620 Villager::CheckForSexAtHome(void)
+bool32_t Villager::CheckForSexAtHome()
+{
+	if ((Flags & 4) && IsSexuallyActive() != 0)
+	{
+		return StartHavingSexAtHome();
+	}
+	return 0;
+}
+
+// BW1W120 007611b0 BW1M100 10587570 Villager::ShallIWaitForDinner(void)
+bool32_t Villager::ShallIWaitForDinner()
+{
+	if (IsHungry() != 0 && HousewifeAskForMeal() == 0)
+	{
+		return 0;
+	}
+	TurnsUntilNextStateChange = (int16_t)((const GVillagerInfo*)info)->WaitAtHome;
+	SetTopState(VILLAGER_STATE_WAIT_FOR_DINNER);
+	return true;
+}
+
+// BW1W120 007611f0 BW1M100 105874c0 Villager::HomeDeleted(void)
+void Villager::HomeDeleted()
+{
+	if (target == GetAbode())
+	{
+		target = NULL;
+	}
+	if (GetAbode() != NULL)
+	{
+		MakeHomeless();
+	}
+	else
+	{
+		TownDeleted();
+	}
+}
+
+// BW1W120 00761220 BW1M100 10587440 Villager::MakeHomeless(void)
+bool Villager::MakeHomeless()
+{
+	// TODO: 96.9% - target saves the result full-width in edi; we store it
+	// byte-width in ebx. Register-allocation tie-break, semantics correct.
+	bool result = MakeHomelessNoStateChange();
+	SetTopState(VILLAGER_STATE_HOMELESS_START);
+	return result;
+}
+
+// BW1W120 00761320 BW1M100 10587160 Villager::HomelessStart(void)
+bool32_t Villager::HomelessStart()
+{
+	GetTown();
+	// TODO: 99.8% - target compares CheckHungry()'s bool result full-width
+	// (`cmp eax,1`); our build emits `cmp al,1`. bool-return width tie-break.
+	if (CheckHungry() != 1 && CheckNeededForSomething() != 1 && CheckHomelessMoveIntoAbode() == 0)
+	{
+		SetupNothingToDo();
+	}
+	return true;
+}
+
+// BW1W120 00761360 BW1M100 10586fd0 Villager::CheckHomelessMoveIntoAbode(void)
 bool32_t Villager::CheckHomelessMoveIntoAbode()
 {
 	Town*  town = GetTown();
@@ -46,4 +259,86 @@ bool32_t Villager::CheckHomelessMoveIntoAbode()
 	abode->AddVillagerToAbode(this);
 	SetTopState(VILLAGER_STATE_GO_HOME);
 	return 1;
+}
+
+// BW1W120 007613f0 BW1M100 10586f90 Villager::VillagerGossips(void)
+bool32_t Villager::VillagerGossips()
+{
+	return true;
+}
+
+// BW1W120 00761400 BW1M100 10586ed0 Villager::SetupAfterTapOnAbode(MapCoords &, VILLAGER_STATES)
+void Villager::SetupAfterTapOnAbode(MapCoords& pos, VILLAGER_STATES previous_state)
+{
+	action.SetState(LIVING_ACTION_INDEX_PREVIOUS, previous_state);
+	SetupMoveToPos(pos, VILLAGER_STATE_AFTER_TAP_ON_ABODE);
+	Flags |= 1;
+}
+
+// BW1W120 00761440 BW1M100 10586e70 Villager::AfterTapOnAbode(void)
+bool32_t Villager::AfterTapOnAbode()
+{
+	// TODO: 85.7% - target zero-extends the byte arg (`xor eax,eax; mov al,[..]`);
+	// our build emits only `mov al,[..]`. Codegen tie-break, semantics correct.
+	PlayAnimThenSetState(action.states[LIVING_ACTION_INDEX_PREVIOUS], 1);
+	return true;
+}
+
+// BW1W120 00761460 BW1M100 100955e0 Villager::CheckSatisfyRelaxation(void)
+bool32_t Villager::CheckSatisfyRelaxation()
+{
+	if (GetTown() != NULL && GetTown()->SetVillagerActivity(this) != 0)
+	{
+		return true;
+	}
+	return false;
+}
+
+// BW1W120 00761800 BW1M100 10586960 Villager::EnterWaitForArtifactDance(unsigned char, unsigned char)
+bool32_t Villager::EnterWaitForArtifactDance(unsigned char param_1, unsigned char param_2)
+{
+	TurnsUntilNextStateChange = 0;
+	return true;
+}
+
+// BW1W120 00761ae0 BW1M100 10586240 Villager::SleepInTent(void)
+bool32_t Villager::SleepInTent()
+{
+	if (TurnsUntilNextStateChange == 0)
+	{
+		if (DoSleeping(1.0f) != 0)
+		{
+			return true;
+		}
+		if (GetAbode() == NULL)
+		{
+			if (CheckHomelessMoveIntoAbode() != 0)
+			{
+				return true;
+			}
+		}
+		if (HomeDecideWhatToDo() != 0 && action.states[LIVING_ACTION_INDEX_TOP] != VILLAGER_STATE_SLEEP_IN_TENT)
+		{
+			return true;
+		}
+		TurnsUntilNextStateChange = (int16_t)((const GVillagerInfo*)info)->RestAtHomeTime;
+	}
+	TurnsUntilNextStateChange--;
+	return true;
+}
+
+// BW1W120 00761b40 BW1M100 100957f0 Villager::ExitAtHome(unsigned char)
+bool32_t Villager::ExitAtHome(unsigned char state)
+{
+	if (g_GVillagerStateTableInfos[state].field_0xd0 == 0)
+	{
+		LeaveHome();
+	}
+	return true;
+}
+
+// BW1W120 00761b70 BW1M100 10586150 Villager::GoHomeFromWorship(void)
+bool32_t Villager::GoHomeFromWorship()
+{
+	return DoGoingHome(VILLAGER_STATE_ARRIVES_HOME_FROM_WORSHIP, VILLAGER_STATE_SLEEP_IN_TENT_FROM_WORSHIP);
 }

--- a/src/Black/VillagerReaction.cpp
+++ b/src/Black/VillagerReaction.cpp
@@ -1,7 +1,12 @@
 #include "Villager.h"
 
+#include "Abode.h"
+#include "Map.h"
 #include "MapCoords.h"
 #include "Reaction.h"
+#include "VillagerStateTableInfo.h"
+
+extern GVillagerStateTableInfo g_GVillagerStateTableInfos[VILLAGER_STATE_LAST_STATE];
 
 // BW1W120 00763390
 bool32_t Villager::IsAvailableForReaction(REACTION param_1)
@@ -16,16 +21,41 @@ bool32_t Villager::IsAvailableForBeliefButNotReaction(REACTION param_1)
 }
 
 // BW1W120 00763440
-void Villager::AddReaction(Reaction* param_1, VILLAGER_STATES param_2) {}
+void Villager::AddReaction(Reaction* reaction, VILLAGER_STATES state)
+{
+	UpdateHowImpressed(reaction, 1);
+	Living::AddReaction(reaction, state);
+}
 
 // BW1W120 00763470
-void Villager::StorePreviousState() {}
+void Villager::StorePreviousState()
+{
+	// TODO: 92.5% - semantically exact; only eax/ecx allocation swap between the state value
+	// and the state*0x114 array-index expression (target copies state to ecx then indexes in eax).
+	VILLAGER_STATES state = (VILLAGER_STATES)(GetFinalState() & VILLAGER_STATE_LAST_STATE);
+	VILLAGER_STATES stateToStore = state;
+	if (g_GVillagerStateTableInfos[state].field_0x20 != 0 || g_GVillagerStateTableInfos[state].field_0xc8 != 0)
+	{
+		stateToStore = (VILLAGER_STATES)this->action.states[LIVING_ACTION_INDEX_PREVIOUS];
+	}
+	this->action.SetState(LIVING_ACTION_INDEX_PREVIOUS, stateToStore);
+}
 
 // BW1W120 007634c0
 void Villager::UpdateHowImpressed(Reaction* param_1, int param_2) {}
 
 // BW1W120 007637d0
-void Villager::StopReacting() {}
+void Villager::StopReacting()
+{
+	if ((uint8_t)Living::GetTopState() == VILLAGER_STATE_DANCE_WHILE_REACTING)
+	{
+		if (IsDancing())
+		{
+			RemoveFromDance(1);
+		}
+	}
+	Living::StopReacting();
+}
 
 // BW1W120 00763800
 bool32_t Villager::SetupMoveToPos(const MapCoords& coord, VILLAGER_STATES end_state)
@@ -34,7 +64,11 @@ bool32_t Villager::SetupMoveToPos(const MapCoords& coord, VILLAGER_STATES end_st
 }
 
 // BW1W120 00763820
-void Villager::SetupReactToMagicTree(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToMagicTree(GameThingWithPos* thing, Reaction* reaction)
+{
+	AddReaction(reaction, VILLAGER_STATE_INITIALISE_BEWILDERED_BY_MAGIC_TREE_REACTION);
+	this->field_0xbc = thing;
+}
 
 // BW1W120 00763850
 uint8_t Villager::FleeFromPredatorPriority(Reaction* param_1, Reaction* param_2)
@@ -49,19 +83,37 @@ uint8_t Villager::ReactToScaffoldPriority(Reaction* param_1, Reaction* param_2)
 }
 
 // BW1W120 00763990
-void Villager::SetupFleeFromPredator(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupFleeFromPredator(GameThingWithPos* thing, Reaction* reaction)
+{
+	if ((uint8_t)GetFinalState() == VILLAGER_STATE_GO_AND_HIDE_IN_NEARBY_BUILDING)
+	{
+		this->field_0x10c = 0.0f;
+		return;
+	}
+	AddReaction(reaction, VILLAGER_STATE_FLEEING_FROM_PREDATOR_REACTION);
+	this->field_0xbc = thing;
+}
 
 // BW1W120 007639d0
 void Villager::SetupReactToFlyingObject(GameThingWithPos* param_1, Reaction* param_2) {}
 
 // BW1W120 00763aa0
-void Villager::SetupLookAtObject(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupLookAtObject(GameThingWithPos* thing, Reaction* reaction)
+{
+	Living::SetupLookAtObject(thing, reaction);
+}
 
 // BW1W120 00763ac0
-void Villager::SetupLookAtSpell(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupLookAtSpell(GameThingWithPos* thing, Reaction* reaction)
+{
+	Living::SetupLookAtObject(thing, reaction);
+}
 
 // BW1W120 00763ae0
-void Villager::SetupLookAtNiceSpell(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupLookAtNiceSpell(GameThingWithPos* thing, Reaction* reaction)
+{
+	SetupLookAtSpell(thing, reaction);
+}
 
 // BW1W120 00763b00
 bool32_t Villager::FleeingFromObjectReaction()
@@ -88,8 +140,23 @@ bool32_t Villager::GoAndHideInNearbyBuilding()
 }
 
 // BW1W120 00763f00
-Abode* Villager::GetAbodeToHideInAtPos(const MapCoords& param_1)
+Abode* Villager::GetAbodeToHideInAtPos(const MapCoords& pos)
 {
+	// TODO: body is structurally exact (90%). Remaining diffs are Abode layout bugs
+	// outside this unit: coords read at [esi+0x2c] but target uses [esi+0x14] (GameThingWithPos
+	// base sits 0x18 bytes too deep in our Abode hierarchy); CanBeHiddenIn dispatches at vtbl
+	// +0x928 but target uses +0x924 (one extra virtual declared before it). Also Abode::CanBeHiddenIn
+	// header return type is `bool` but its mangling is UAEIXZ (unsigned int) -> test al,al vs eax,eax.
+	Abode* abode = (Abode*)pos.ToMap()->FindFixedOnMap(NULL);
+	while (abode != NULL)
+	{
+		if (abode->IsAbode() && abode->coords.x == pos.x && abode->coords.z == pos.z && abode->IsAvailable() &&
+		    abode->CanBeHiddenIn())
+		{
+			return abode;
+		}
+		abode = (Abode*)pos.ToMap()->FindFixedOnMap(abode);
+	}
 	return NULL;
 }
 
@@ -100,23 +167,32 @@ bool32_t Villager::LookToSeeIfItIsSafe()
 }
 
 // BW1W120 007640a0
-uint32_t Villager::NumGameTurnsToReactToPredatorFunction(GameThingWithPos* param_1, uint32_t param_2, float param_3)
+uint32_t Villager::NumGameTurnsToReactToPredatorFunction(GameThingWithPos* thing, uint32_t param_2, float param_3)
 {
-	return 0;
+	VILLAGER_STATES state = GetFinalState();
+	if ((uint8_t)state != VILLAGER_STATE_GO_AND_HIDE_IN_NEARBY_BUILDING &&
+	    (uint8_t)state != VILLAGER_STATE_LOOK_TO_SEE_IF_IT_IS_SAFE)
+	{
+		return Living::NumGameTurnsToReactToPredatorFunction(thing, param_2, param_3);
+	}
+	return 0x7fffffff;
 }
 
 // BW1W120 007640e0
-uint32_t Villager::NumGameTurnsBeforeReactingAgainToPredatorFunction(GameThingWithPos* param_1, uint32_t param_2,
+uint32_t Villager::NumGameTurnsBeforeReactingAgainToPredatorFunction(GameThingWithPos* thing, uint32_t param_2,
                                                                      float param_3)
 {
-	return 0;
+	if ((uint8_t)GetFinalState() == VILLAGER_STATE_LOOK_TO_SEE_IF_IT_IS_SAFE)
+	{
+		return 0;
+	}
+	return Living::NumGameTurnsBeforeReactingAgainToPredatorFunction(thing, param_2, param_3);
 }
 
 // BW1W120 00764110
-uint32_t Villager::NumGameTurnsToReactToBurningObjectFunction(GameThingWithPos* param_1, uint32_t param_2,
-                                                              float param_3)
+uint32_t Villager::NumGameTurnsToReactToBurningObjectFunction(GameThingWithPos* thing, uint32_t param_2, float param_3)
 {
-	return 0;
+	return StandardNumGameTurnsToReactFunction(thing, param_2, param_3);
 }
 
 // BW1W120 00764130
@@ -148,7 +224,7 @@ bool32_t Villager::LookingAtObjectReaction()
 // BW1W120 00764310
 bool32_t Villager::FleeingAndLookingAtObjectReaction()
 {
-	return false;
+	return LookingAtObjectReaction();
 }
 
 // BW1W120 00764320
@@ -230,10 +306,16 @@ bool32_t Villager::ArrivesAtWoodReaction()
 }
 
 // BW1W120 007648d0
-uint32_t Villager::StandardNumGameTurnsBeforeReactingToWoodAgainFunction(GameThingWithPos* param_1, uint32_t param_2,
+uint32_t Villager::StandardNumGameTurnsBeforeReactingToWoodAgainFunction(GameThingWithPos* thing, uint32_t param_2,
                                                                          float param_3)
 {
-	return 0;
+	VILLAGER_STATES state = (VILLAGER_STATES)(GetFinalState() & VILLAGER_STATE_LAST_STATE);
+	if (state >= VILLAGER_STATE_FORESTER_MOVE_TO_FOREST &&
+	    (state <= VILLAGER_STATE_FORESTER_CHOPS_TREE || state == VILLAGER_STATE_FORESTER_FINISHED_FORESTERING))
+	{
+		return 0;
+	}
+	return StandardNumGameTurnsBeforeReactingAgainFunction(thing, param_2, param_3);
 }
 
 // BW1W120 00764920
@@ -374,7 +456,7 @@ bool32_t Villager::GoToTeleportReaction()
 // BW1W120 00766380
 bool32_t Villager::GoToTeleportReactionQuickly()
 {
-	return false;
+	return GoToTeleportReaction();
 }
 
 // BW1W120 00766390
@@ -432,16 +514,24 @@ bool32_t Villager::MournDeadPerson()
 }
 
 // BW1W120 007668c0
-void Villager::SetupReactToFainting(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToFainting(GameThingWithPos* thing, Reaction* reaction)
+{
+	this->field_0xbc = this;
+	AddReaction(reaction, VILLAGER_STATE_FAINTING_REACTION);
+}
 
 // BW1W120 007668e0
 bool32_t Villager::FaintingReaction()
 {
-	return false;
+	return true;
 }
 
 // BW1W120 007668f0
-void Villager::SetupReactToConfused(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToConfused(GameThingWithPos* thing, Reaction* reaction)
+{
+	this->field_0xbc = this;
+	AddReaction(reaction, VILLAGER_STATE_START_CONFUSED_REACTION);
+}
 
 // BW1W120 00766910
 bool32_t Villager::StartConfusedReaction()
@@ -462,7 +552,11 @@ uint8_t Villager::ReactToFallingTreePriority(Reaction* param_1, Reaction* param_
 }
 
 // BW1W120 00766a20
-void Villager::SetupReactToFallingTree(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToFallingTree(GameThingWithPos* thing, Reaction* reaction)
+{
+	AddReaction(reaction, VILLAGER_STATE_FLEEING_FROM_OBJECT_REACTION);
+	this->field_0xbc = thing;
+}
 
 // BW1W120 00766a50
 uint8_t Villager::ReactToCrowdPriority(Reaction* param_1, Reaction* param_2)
@@ -471,7 +565,11 @@ uint8_t Villager::ReactToCrowdPriority(Reaction* param_1, Reaction* param_2)
 }
 
 // BW1W120 00766a60
-void Villager::SetupReactToCrowd(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToCrowd(GameThingWithPos* thing, Reaction* reaction)
+{
+	AddReaction(reaction, VILLAGER_STATE_CROWD_REACTION);
+	this->field_0xbc = thing;
+}
 
 // BW1W120 00766a90
 bool32_t Villager::CrowdReaction()
@@ -522,7 +620,11 @@ uint8_t Villager::ReactToTownCelebrationPriority(Reaction* param_1, Reaction* pa
 }
 
 // BW1W120 007671e0
-void Villager::SetupReactToBreeder(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToBreeder(GameThingWithPos* thing, Reaction* reaction)
+{
+	AddReaction(reaction, VILLAGER_STATE_REACT_TO_BREEDER);
+	this->field_0xbc = thing;
+}
 
 // BW1W120 00767210
 uint8_t Villager::ReactToBreederPriority(Reaction* param_1, Reaction* param_2)
@@ -533,17 +635,31 @@ uint8_t Villager::ReactToBreederPriority(Reaction* param_1, Reaction* param_2)
 // BW1W120 00767280
 bool32_t Villager::ReactToBreeder()
 {
+	if (this->field_0xbc != NULL && this->field_0xbc->IsVillager(NULL))
+	{
+		GoAndHaveSexWith((Villager*)this->field_0xbc);
+		return true;
+	}
 	return false;
 }
 
 // BW1W120 007672c0
-bool32_t Villager::GoAndHaveSexWith(Villager* param_1)
+bool32_t Villager::GoAndHaveSexWith(Villager* mate)
 {
-	return false;
+	// TODO: target returns MakeVillagesMeet's bool result raw (no widening); our
+	// bool32_t->bool conversion emits a trailing `and eax,0xff`. ~92% otherwise exact.
+	bool32_t result = MakeVillagesMeet(mate, VILLAGER_STATE_START_HAVING_SEX, 0.562f);
+	this->TargetThing = mate;
+	mate->TargetThing = this;
+	return result;
 }
 
 // BW1W120 007672f0
-void Villager::SetupReactToVillagerInHand(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToVillagerInHand(GameThingWithPos* thing, Reaction* reaction)
+{
+	AddReaction(reaction, VILLAGER_STATE_WAIT_FOR_MATE);
+	this->field_0xbc = thing;
+}
 
 // BW1W120 00767320
 uint8_t Villager::ReactToVillagerInHandPriority(Reaction* param_1, Reaction* param_2)
@@ -560,13 +676,13 @@ bool32_t Villager::WaitForMate()
 // BW1W120 00767410
 bool32_t Villager::EnterDrowning(unsigned char param_1, unsigned char param_2)
 {
-	return false;
+	return true;
 }
 
 // BW1W120 00767420
 bool32_t Villager::ExitDrowning(unsigned char param_1)
 {
-	return false;
+	return true;
 }
 
 // BW1W120 00767430
@@ -576,13 +692,20 @@ uint8_t Villager::ReactToBurningObjectInHandPriority(Reaction* param_1, Reaction
 }
 
 // BW1W120 00767490
-void Villager::SetupReactToBurningObjectInHand(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToBurningObjectInHand(GameThingWithPos* thing, Reaction* reaction)
+{
+	this->field_0xbc = thing;
+	AddReaction(reaction, VILLAGER_STATE_FLEEING_FROM_OBJECT_REACTION);
+}
 
 // BW1W120 007674b0
 void Villager::SetupReactToMagicShieldStruck(GameThingWithPos* param_1, Reaction* param_2) {}
 
 // BW1W120 00767520
-void Villager::SetupReactToMagicShieldDestroyed(GameThingWithPos* param_1, Reaction* param_2) {}
+void Villager::SetupReactToMagicShieldDestroyed(GameThingWithPos* thing, Reaction* reaction)
+{
+	SetupPanicReaction(reaction, thing->coords);
+}
 
 // BW1W120 00767540
 uint8_t Villager::ReactToMagicShieldStruckPriority(Reaction* param_1, Reaction* param_2)

--- a/src/Black/VillagerStates.cpp
+++ b/src/Black/VillagerStates.cpp
@@ -100,11 +100,17 @@ bool32_t Villager::ArrivesAtStoragePitForDropOff()
 }
 
 // BW1W120 00769830
+// TODO: 86.4% — state arg corrected to ARRIVES_AT_STORAGE_PIT_FOR_FOOD (was wrongly 0).
+// Residual is retbuf-arg-order (same as sibling GotoStoragePitForDropOff): target
+// materialises the GetArrivePos/GetResourceDropoffPos retbuf temp before pushing the
+// constant state arg; ours pushes the state first. Whole-function register-pressure
+// scheduler interaction — see CHEATSHEET retbuf-arg-order. Defer.
 bool32_t Villager::GotoStoragePitForFood()
 {
 	if (GetStoragePit() != NULL && GetStoragePit()->IsFunctional())
 	{
-		SetupMoveToOnFootpath(*GetStoragePit(), GetStoragePit()->GetArrivePos(), 0);
+		SetupMoveToOnFootpath(*GetStoragePit(), GetStoragePit()->GetArrivePos(),
+		                      VILLAGER_STATE_ARRIVES_AT_STORAGE_PIT_FOR_FOOD);
 		return true;
 	}
 	SetupMoveToWithHug(GetResourceDropoffPos(RESOURCE_TYPE_FOOD), VILLAGER_STATE_ARRIVES_AT_STORAGE_PIT_FOR_FOOD);
@@ -285,7 +291,7 @@ bool32_t Villager::EnterBreeder(unsigned char param_1, unsigned char param_2)
 }
 
 // BW1W120 0076a2d0
-bool32_t Villager::ExitBreeder(unsigned char param_1)
+bool32_t Villager::ExitBreeder(unsigned char state)
 {
 	Reaction::RemoveAllReactionsOfTypeInitiatedByObject(this, REACTION_REACT_TO_BREEDER);
 	return true;
@@ -416,13 +422,35 @@ bool32_t Villager::InHand()
 // BW1W120 0076afe0
 uint32_t Villager::EnterInHand(VILLAGER_STATES param_1, VILLAGER_STATES param_2)
 {
-	return 0;
+	// field_0x10c is a float slot elsewhere; this state stashes the (remapped) disciple
+	// type into its raw bits, hence the reinterpret store rather than a float conversion.
+	uint32_t discipleType = DiscipleType;
+	if (discipleType == VILLAGER_DISCIPLE_MISSIONARY)
+	{
+		discipleType = VILLAGER_DISCIPLE_NONE;
+	}
+	*(uint32_t*)&field_0x10c = discipleType;
+	return 1;
 }
 
 // BW1W120 0076b000
+// TODO: 88.9% — semantics verified. Only diff is the epilogue: target sandwiches
+// `mov eax,esi` between `pop edi` and `pop esi`; ours emits it before both pops.
+// Toy-tested (named-result, !=0 test, early-return) — the result/if/return-result form
+// is confirmed correct (early-return diverges into 1-reg + immediate return), leaving a
+// whole-TU epilogue scheduler tie (bool-return-full-eax-epilogue family). Defer.
 int Villager::ExitInHand(VILLAGER_STATES state)
 {
-	return 0;
+	int result = Living::ExitInHand(state);
+	if (result == 1)
+	{
+		Abode* abode = GetAbode();
+		if (abode != NULL)
+		{
+			abode->field_0x7c &= ~0x10;
+		}
+	}
+	return result;
 }
 
 // BW1W120 0076b030
@@ -432,11 +460,11 @@ bool32_t Villager::IsInACreaturesHand()
 }
 
 // BW1W120 0076b060
-bool32_t Villager::SetupWaitForCounter(unsigned short param_1, VILLAGER_STATES param_2)
+bool32_t Villager::SetupWaitForCounter(unsigned short counter, VILLAGER_STATES state)
 {
-	if (SetCurrentAndDestinationState(VILLAGER_STATE_WAIT_FOR_COUNTER, param_2) == 1)
+	if (SetCurrentAndDestinationState(VILLAGER_STATE_WAIT_FOR_COUNTER, state) == 1)
 	{
-		TurnsUntilNextStateChange = param_1;
+		TurnsUntilNextStateChange = counter;
 		return true;
 	}
 	return false;
@@ -449,9 +477,19 @@ uint32_t Villager::SetupPauseForASecond(VILLAGER_STATES state)
 }
 
 // BW1W120 0076b0b0
+// TODO: 98.6% — semantics verified. Residual: target calls Living::IsReadyForNewAnimation
+// as the void-mangled symbol (?...@QAEXI@Z) and does `test eax,eax`; ours calls the
+// bool-mangled symbol (Living.h declares it `bool`) and does `test al,al`. Target's 32-bit
+// eax test implies a 32-bit return, but the real symbol is `void` (QAEXI) — the
+// void-call-eax-probed-by-caller idiom. Fixing needs Living.h's return type (shared header,
+// affects Living.cpp + symbols.txt) — dispatcher territory. Defer.
 bool32_t Villager::PauseForASecond()
 {
-	return false;
+	if (IsReadyForNewAnimation(1))
+	{
+		SetTopStateToFinal();
+	}
+	return true;
 }
 
 // BW1W120 0076b0d0
@@ -497,6 +535,10 @@ bool32_t Villager::SitAndChillout()
 }
 
 // BW1W120 0076b570
+// TODO: 76% — semantics verified (2 loads + store + `mov eax,1`). Target schedules the
+// `mov [ecx+0x58],dx` store BEFORE `mov eax,1`; ours emits `mov eax,1` first. Toy-tested
+// (return 1/true, value-local, ptr-local, this-> forms) all reproduce our order under the
+// exact build flags — a whole-TU scheduler tie-break, not a local source shape. Defer.
 bool32_t Villager::EnterSitAndChillOut(unsigned char param_1, unsigned char param_2)
 {
 	TurnsUntilNextStateChange = ((const GVillagerInfo*)info)->InitialChillOutTime;

--- a/tools/check_stub_addrs.py
+++ b/tools/check_stub_addrs.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate `// BW1W120 <w> BW1M100 <m> <sig>` stub comments in .cpp files against
+the authoritative header declarations.
+
+The headers under src/ and include/ carry the canonical per-symbol comment (both the
+Windows BW1W120 address and the Mac BW1M100 address). When a stub is added to a .cpp,
+its comment must be copied verbatim from the header; retyping the Mac address is an easy
+copy error that silently corrupts the Mac address map. This script keys on the reliable
+BW1W120 address and reports any .cpp stub whose BW1M100 address (or demangled signature)
+disagrees with the header.
+
+Usage:
+    python3 tools/check_stub_addrs.py [file.cpp ...]     # default: all src/Black/*.cpp
+    python3 tools/check_stub_addrs.py --fix file.cpp      # rewrite Mac addr to match header
+
+Exit status is non-zero if any mismatch is found (CI-friendly).
+"""
+import glob
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RX = re.compile(r'BW1W120\s+([0-9a-fA-F]+)\s+BW1M100\s+([0-9a-fA-F]+)\s+(.*?)\s*$')
+
+
+def load_headers():
+    """BW1W120 addr (lower) -> (BW1M100 addr, signature, header path)."""
+    hdr = {}
+    pats = [os.path.join(ROOT, "src", "**", "*.h"),
+            os.path.join(ROOT, "include", "**", "*.h")]
+    for pat in pats:
+        for h in glob.glob(pat, recursive=True):
+            for line in open(h, errors="ignore"):
+                m = RX.search(line)
+                if m:
+                    hdr.setdefault(m.group(1).lower(),
+                                   (m.group(2).lower(), m.group(3).strip(), h))
+    return hdr
+
+
+def main(argv):
+    fix = "--fix" in argv
+    files = [a for a in argv if not a.startswith("--")]
+    if not files:
+        files = sorted(glob.glob(os.path.join(ROOT, "src", "Black", "*.cpp")))
+
+    hdr = load_headers()
+    if not hdr:
+        print("no BW1W120/BW1M100 header comments found — nothing to check against")
+        return 1
+
+    bad = 0
+    for path in files:
+        try:
+            lines = list(open(path, errors="ignore"))
+        except OSError as e:
+            print(f"skip {path}: {e}")
+            continue
+        changed = False
+        for i, line in enumerate(lines):
+            m = RX.search(line)
+            if not m:
+                continue
+            w, mac = m.group(1).lower(), m.group(2).lower()
+            if w not in hdr:
+                # Not necessarily wrong (local helper, non-symbol), but worth flagging.
+                continue
+            hmac, hsig, hh = hdr[w]
+            if mac != hmac:
+                bad += 1
+                rel = os.path.relpath(path, ROOT)
+                print(f"{rel}:{i + 1}  BW1W120 {w}: BW1M100 {mac} != header {hmac}  ({hsig})")
+                if fix:
+                    lines[i] = line.replace(f"BW1M100 {mac}", f"BW1M100 {hmac}", 1)
+                    changed = True
+        if fix and changed:
+            open(path, "w").writelines(lines)
+            print(f"  -> fixed {os.path.relpath(path, ROOT)}")
+
+    if bad == 0:
+        print(f"OK: {len(files)} file(s), no Mac-address mismatches")
+        return 0
+    print(f"\n{bad} mismatch(es){' (fixed)' if fix else ''}")
+    return 0 if fix else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
66 new function matches across 8 Villager units (Reaction, Home, Football, States, Civic, Food, Child) plus improvements; readability clean-up (param names, one magic number). Header signature fixes verified against mangling (const/ref/bool width). Fixed 9 corrupted BW1M100 stub addresses.

Skill: cheatsheet grown game-wide with a mangled-name decoder and systemic-blocker taxonomy; SKILL.md stub-copy rule + generalization notes; add tools/check_stub_addrs.py Mac-address validator.