### PR TITLE
Wire MSVC 6.0 SP4 toolchain and libs for BW1W100/BW1W110

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Scaffolded from [encounter/dtk-template](https://github.com/encounter/dtk-templa
 
 Supported versions:
 
-- `BW1W100` — Windows v1.00 (PE/COFF, MSVC 6.0 SP5 with `/OPT:ICF`)
-- `BW1W110` — Windows v1.10 (PE/COFF, MSVC 6.0 SP5)
+- `BW1W100` — Windows v1.00 (PE/COFF, MSVC 6.0 SP4 with `/OPT:ICF`)
+- `BW1W110` — Windows v1.10 (PE/COFF, MSVC 6.0 SP4)
 - `BW1W120` — Windows v1.20 (PE/COFF, MSVC 6.0 SP5)
 
 Work in progress:

--- a/config/BW1W100/build.sha1
+++ b/config/BW1W100/build.sha1
@@ -8,5 +8,5 @@ ef08506f38ea430b9c8348e0f9d44385964ff4d6  orig/BW1W100/LHMultiplayerR.dll
 ef08506f38ea430b9c8348e0f9d44385964ff4d6  build/BW1W100/LHMultiplayer.dll
 64a22b88a51adc4bc119777642263e419ea8d09e  orig/BW1W100/LHDialogLib.dll
 64a22b88a51adc4bc119777642263e419ea8d09e  build/BW1W100/LHDialog.dll
-8e8c7f7dcf2121114ff73ad65112d8eba51675fe  build/lib/libcmt.lib
-792e20d86eb741bc6f111f3ca439620f7b2cf566  build/lib/libcpmt.lib
+05f7c53a28401bfa36cf3367142cde169aba330a  build/lib/libcmt.lib
+bffeaaf36e3b656efb924d46eb11ae04b2fae5d1  build/lib/libcpmt.lib

--- a/config/BW1W110/build.sha1
+++ b/config/BW1W110/build.sha1
@@ -8,5 +8,5 @@
 184601784d2eb1a2f999f79cd032128cf3196b38  build/BW1W110/LHMultiplayer.dll
 64a22b88a51adc4bc119777642263e419ea8d09e  orig/BW1W110/LHDialogLib.dll
 64a22b88a51adc4bc119777642263e419ea8d09e  build/BW1W110/LHDialog.dll
-8e8c7f7dcf2121114ff73ad65112d8eba51675fe  build/lib/libcmt.lib
-792e20d86eb741bc6f111f3ca439620f7b2cf566  build/lib/libcpmt.lib
+05f7c53a28401bfa36cf3367142cde169aba330a  build/lib/libcmt.lib
+bffeaaf36e3b656efb924d46eb11ae04b2fae5d1  build/lib/libcpmt.lib

--- a/configure.py
+++ b/configure.py
@@ -166,16 +166,24 @@ config.dtk_tag = "v0.0.22"
 config.objdiff_tag = "v3.7.2"
 config.sjiswrap_tag = "v1.2.2"
 config.wibo_tag = "1.2.0"
-config.compilers_tag = "6.5"  # MSVC 6.0 SP5
+# MSVC toolchain per version. BW1W100/BW1W110 = VC6 SP4, BW1W120 = SP5 (Rich
+# header build-number comparison against dishather/richprint comp_id.txt). SP4
+# never shipped its own libcpmt.lib, so those fall back to the RTM (6.0) copy.
+config.compilers_tag = {
+    "BW1W100": "6.4",
+    "BW1W110": "6.4",
+    "BW1W120": "6.5",
+}[config.version]
+config.linker_version = f"MSVC/{config.compilers_tag}"
 config.lld_link_tag = "bw1-decomp-018"
 # Static libraries to pull verbatim CRT objects from (see LibObject). They are
 # not committed and not downloaded — you must supply them yourself: place each
 # .lib at orig/libs/<package>/<lib>.lib. See the README for how to obtain them.
 config.static_libs = {
-    "libcmt": "msvc6.5",    # multithreaded C runtime (CRT) — VC6 SP5
-    "libcpmt": "msvc6.5",   # multithreaded C++ standard library (iostreams, RTTI) — VC6 SP5
-    "amaths": "amaths-2.0",  # Intel Approximate Math Library (SSE sin/cos/tan/atan/exp/log/pow)
-}
+    "BW1W100": {"libcmt": "msvc6.4", "libcpmt": "msvc6.0", "amaths": "amaths-2.0"},
+    "BW1W110": {"libcmt": "msvc6.4", "libcpmt": "msvc6.0", "amaths": "amaths-2.0"},
+    "BW1W120": {"libcmt": "msvc6.5", "libcpmt": "msvc6.5", "amaths": "amaths-2.0"},
+}[config.version]
 
 # Project
 config.config_path = Path("config") / config.version / "config.yml"
@@ -218,7 +226,6 @@ config.custom_build_rules = [
         "description": "PATCH $in",
     },
 ]
-config.linker_version = "MSVC/6.5"
 _msvc_dir = f"build/compilers/{config.linker_version}"
 _patch_stamp = f"build/{config.version}/patched_compiler_headers"
 config.custom_build_steps = {

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -10,12 +10,14 @@ Everything else is downloaded automatically by `configure.py` on first run:
 
 - `dtk` — [openblack/decomp-toolkit](https://github.com/openblack/decomp-toolkit) build (split + link verification)
 - `lld-link` — [openblack/llvm-project](https://github.com/openblack/llvm-project) release (PE linker)
-- MSVC 6.0 SP5 compilers — pulled at the version pinned in `configure.py`
+- MSVC 6.0 compilers (SP5 for BW1W120, SP4 for BW1W100/BW1W110) — pulled at the version pinned in `configure.py`
 - `objdiff-cli` — diff report generator
 
-Three things are **not** downloaded and must be supplied by hand under `orig/` (see [Getting Started](getting_started.md)):
+These are **not** downloaded and must be supplied by hand under `orig/` (see [Getting Started](getting_started.md)):
 
-- MSVC 6.0 SP5 static CRT libs — `orig/libs/msvc6.5/libcmt.lib`, `orig/libs/msvc6.5/libcpmt.lib` (from `VC98\Lib`)
+- MSVC 6.0 SP5 static CRT libs (BW1W120) — `orig/libs/msvc6.5/libcmt.lib`, `orig/libs/msvc6.5/libcpmt.lib` (from `VC98\Lib`)
+- MSVC 6.0 SP4 `libcmt.lib` (BW1W100/BW1W110) — `orig/libs/msvc6.4/libcmt.lib`
+- MSVC 6.0 RTM `libcpmt.lib` (also BW1W100/BW1W110; SP4 never shipped its own) — `orig/libs/msvc6.0/libcpmt.lib`
 - DirectX 7.0 DDK — headers in `orig/directx7.0/include/` and libs in `orig/directx7.0/lib/`
 - Intel Approximate Math Library — `orig/libs/amaths-2.0/amaths.lib` (linked verbatim for SSE `sin`/`cos`/`tan`/`atan`/`exp`/`log`/`pow`)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,15 +15,33 @@ See [Dependencies](dependencies.md) first.
 
    The Windows builds expect a **decrypted** exe. The original retail discs ship the executable wrapped in SafeDisc 2 / Macrovision protection. Decrypting it is currently undocumented tribal knowledge — if you don't already have a decrypted copy, ask in the project's Discord/issue tracker rather than guessing at a tool name.
 
-3. Place the MSVC 6.0 SP5 static CRT libraries and the DirectX 7.0 SDK headers under `orig/` (they are not committed and not downloaded).
+3. Place the MSVC 6.0 static CRT libraries and the DirectX 7.0 SDK headers under `orig/` (they are not committed and not downloaded).
 
-   **MSVC 6.0 SP5 static libs → `orig/libs/msvc6.5/`**
+   BW1W120 was built with VC6 **SP5**; BW1W100/BW1W110 with VC6 **SP4** (confirmed via Rich header build-number comparison — see `configure.py`). `configure.py` picks the right package automatically based on `--version`, so both sets need to be present side by side if you plan to work on more than one version.
+
+   **MSVC 6.0 SP5 static libs → `orig/libs/msvc6.5/`** (BW1W120)
 
    Needed: `libcmt.lib` and `libcpmt.lib`. If you have a Visual C++ 6.0 (SP5) install, copy them straight from `VC98\Lib`. Otherwise pull them from a plain ISO of the SP5 disc on the Internet Archive, item [`MSDN_VisualStudio_6.0_SP5_MASM_6.11_Visual_C_1.2`](https://archive.org/details/MSDN_VisualStudio_6.0_SP5_MASM_6.11_Visual_C_1.2) (`VS60SP5_EN`, byte-verified identical to the genuine SP5 CD):
 
    1. Download `MSDN_VisualStudio_6.0_SP5_MASM_6.11_Visual_C++_1.2.iso` from that item. It's a plain ISO9660 image — no proprietary disc-image format, no conversion step.
    2. Extract `ENGLISH/VS60SP5/VC98/LIB/LIBCMT.LIB` and `LIBCPMT.LIB` with `7z e <iso> "*LIBCMT.LIB" "*LIBCPMT.LIB" -r`, or mount the ISO directly (`mount -o loop` on Linux; double-click on Windows/macOS).
    3. Copy the two files to `orig/libs/msvc6.5/libcmt.lib` and `orig/libs/msvc6.5/libcpmt.lib`. Filenames are matched case-insensitively; lowercase is fine.
+
+   **MSVC 6.0 SP4 `libcmt.lib` → `orig/libs/msvc6.4/`** (BW1W100/BW1W110)
+
+   From the Internet Archive item [`msdn-disc0034-january-2001-x06-11596`](https://archive.org/details/msdn-disc0034-january-2001-x06-11596) (a plain ISO, no disc-image conversion needed):
+
+   1. Download `1_V60SP4_DE.iso`.
+   2. Extract `GERMAN/VS60SP4/VC98/LIB/LIBCMT.LIB` with `7z e <iso> "*LIBCMT.LIB" -r`, or mount directly.
+   3. Copy it to `orig/libs/msvc6.4/libcmt.lib`.
+
+   **MSVC 6.0 RTM `libcpmt.lib` → `orig/libs/msvc6.0/`** (also BW1W100/BW1W110)
+
+   SP4 never shipped its own `libcpmt.lib` — checked three independent SP4 discs, none include it, since Microsoft only redistributes files that changed for a given service pack. The original 1998 RTM copy is the right one (a real SP4-era machine would still have it, untouched, in `VC98\Lib`). It's byte-different from SP5's, so don't substitute that one. From the Internet Archive item [`visualstudiov60enterpriseedition_199807`](https://archive.org/details/visualstudiov60enterpriseedition_199807):
+
+   1. Download Disc 1 (`...(X03-78941)(Microsoft Corporation)(August 1998).iso`, a plain ISO).
+   2. Extract `VC98/LIB/LIBCPMT.LIB` with `7z e <iso> "*LIBCPMT.LIB" -r`, or mount directly.
+   3. Copy it to `orig/libs/msvc6.0/libcpmt.lib`.
 
    **DirectX 7.0 DDK → `orig/directx7.0/`**
 

--- a/tools/project.py
+++ b/tools/project.py
@@ -2023,6 +2023,7 @@ def generate_objdiff_config(
         "Wii/1.5": "mwcc_43_188",
         "Wii/1.6": "mwcc_43_202",
         "Wii/1.7": "mwcc_43_213",
+        "MSVC/6.4": "msvc6.4",
         "MSVC/6.5": "msvc6.5",
     }
 


### PR DESCRIPTION
Select the right compiler package and static libs per version instead of hardcoding SP5 everywhere. BW1W100/BW1W110 (confirmed VC6 SP4 via Rich header build-number comparison) now pull compilers_tag "6.4" and libcmt.lib from orig/libs/msvc6.4/; BW1W120 keeps SP5 (msvc6.5) unchanged. Both coexist side by side, keyed off config.version.

libcpmt.lib needed extra care: checked three independent SP4 discs and none ship it (SP4 only reships files that changed since SP3, and this one didn't). Use the original 1998 RTM copy instead -- byte-verified different from SP5's, so it isn't a case of "any old libcpmt.lib will do".

Fixes build.sha1 for BW1W100/BW1W110, which still listed the SP5 hashes for build/lib/libcmt.lib and build/lib/libcpmt.lib (a leftover placeholder from before this split existed). Documents both new orig/libs/ sources in getting_started.md/dependencies.md. The actual .lib files themselves are supplied via bw1-build, parallel to the existing msvc6.5/amaths-2.0 libs.